### PR TITLE
Removing conflict markers inherited from SVN by accident.

### DIFF
--- a/bootcamps/faq.html
+++ b/bootcamps/faq.html
@@ -57,14 +57,9 @@ delivery. Our experience is consistent with recent research: students
 learn best in a <em>blended</em> environment that combines directed
 in-person instruction with self-directed online learning. We have
 therefore borrowed the boot camp format used so successfully by the
-<<<<<<< .mine
-University of Wisconsin - Madison's <a href="https://github.com/thehackerwithin">Hacker Within</a>
-group, and are using it as a lead-in to our online material.</p>
-=======
 University of Wisconsin - Madison's
 <a href="https://github.com/thehackerwithin">Hacker Within</a> group,
 and are using it as a lead-in to our online material.</p>
->>>>>>> .r3420
 
 <p>As well as improving learning, boot camps solve two other recurring
 problems. Researchers are busy people who often cannot make time for a


### PR DESCRIPTION
The boot camp FAQ had some SVN conflict markers in it, which tripped up the web site compiler.
