### PR TITLE
Updated links in about.html to point to blah/index.html

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -18,13 +18,13 @@
   Software Carpentry began in 1998 as a week-long training course at
   <a href="http://lanl.gov">Los Alamos National Laboratory</a>.
   With support from the <a href="http://www.python.org/psf/">Python Software Foundation</a>,
-  we released <a href="{{root_path}}/3_0/">Version 3</a> of our materials
+  we released <a href="{{root_path}}/3_0/index.html">Version 3</a> of our materials
   under an open license in 2004,
   and in 2010,
   with support from <a href="credits.html">several new sponsors</a>,
-  we produced the online video tutorials of <a href="{{root_path}}/4_0/">Version 4</a>.
-  Our main focus now is <a href="{{root_path}}/bootcamps/">intensive two-day boot camps</a>,
-  and we hope to release <a href="{{root_path}}/book/">a new version of our material</a> in 2013.
+  we produced the online video tutorials of <a href="{{root_path}}/4_0/index.html">Version 4</a>.
+  Our main focus now is <a href="{{root_path}}/bootcamps/index.html">intensive two-day boot camps</a>,
+  and we hope to release <a href="{{root_path}}/book/index.html">a new version of our material</a> in 2013.
 </p>
 
 <p>


### PR DESCRIPTION
There were a few links in the about.html page that pointed to /bootcamps/, /book/, etc..  I've changed these so that they point to the index.html file in the folder.  I did that so the links are unambiguous, and there is no need to worry about URL rewriting problems in the future.  
