### PR TITLE
Added URL redirects for the About and Bootcamp pages (and subpages)

### DIFF
--- a/_htaccess
+++ b/_htaccess
@@ -4,15 +4,17 @@ RewriteEngine On
 RewriteBase /
 AddDefaultCharset UTF-8
 
-#
-# word-press blog URLs
-#
-
 # redirect URLs to a day to the main blog page 
 RewriteCond %{REQUEST_URI} ^/\d\d\d\d/\d\d/\d\d/$
 RewriteRule ^(.*) /blog/index.html [R,L]
 
-# redirect URLs that have a year and day to the /blog/ folder
+# redirect urls that are only to a month to the main blog page
+# since we don't have these monthly pages any longer
+RewriteCond %{REQUEST_URI} ^/\d\d\d\d/\d\d/$
+RewriteRule ^(.*) /blog/index.html [R,L]
+
+# redirect URLs that have a year and month to the /blog/ folder
+# since these are likely old links to individual blog pages
 RewriteCond %{REQUEST_URI} ^/\d\d\d\d/\d\d/
 RewriteRule ^(.*) /blog/$1 [R,L]
 
@@ -21,8 +23,30 @@ RewriteCond %{REQUEST_URI} ^/blog/?$
 RewriteRule .* /blog/index.html [R,L]
 
 # redirect blog URLs that don't end in .html so that they do
+# since this is probably an old blog page link
 RewriteCond %{REQUEST_URI} ^/blog
 RewriteCond %{REQUEST_URI} !.html$
 RewriteRule ^(.*?)/?$ $1.html [R,L]
+
+# wordpress bootcamps URLs
+RewriteCond %{REQUEST_URI} ^/boot-camps/
+RewriteRule ^(.*) /bootcamps/ [R,L]
+
+# wordpress bootcamps category URLs
+RewriteCond %{REQUEST_URI} ^/category/boot-camp/
+RewriteRule ^(.*) /bootcamps/ [R,L]
+
+# About team page
+RewriteCond %{REQUEST_URI} ^/about/our-team/?$
+RewriteRule ^(.*) /about/team.html [R,L]
+
+# Other about pages 
+RewriteCond %{REQUEST_URI} ^/about/.*$
+RewriteCond %{REQUEST_URI} !.html$
+RewriteRule ^(.*?)/?$ $1.html [R,L]
+
+# reading list 
+RewriteCond %{REQUEST_URI} ^/4_0/reading/?$
+RewriteRule ^(.*) /about/biblio.html [R,L]
 
 </IfModule>


### PR DESCRIPTION
There are a few of the Wordpress pages that have been indexed by Google whose links no longer work.  I've added redirects to the .htaccess file to point people to either the proper page or some sensible landing page instead (for instance, /blog/index.html if the blog page they were looking for no longer exists). 
