### PR TITLE
Make the footer mailto link a label to match the GitHub link

### DIFF
--- a/_base.html
+++ b/_base.html
@@ -126,9 +126,17 @@
       </div>
 
       <div class="footer">
-        <a href="{{root_path}}/license.html"><img src="{{root_path}}/img/creative-commons-attribution-license.png" alt="Creative Commons Attribution License" /></a>
-        <span class="label"><a href="https://github.com/swcarpentry">Fork us on github</a></span>
-        <a class="pull-right bugreport" href="mailto:{{contact_email}}?subject=bug%20in%20{{filename}}">Report a bug</a>
+        <a href="{{root_path}}/license.html">
+          <img src="{{root_path}}/img/creative-commons-attribution-license.png" alt="Creative Commons Attribution License" />
+        </a>
+        <span class="pull-right">
+          <a class="label"
+             href="https://github.com/swcarpentry">Fork us on GitHub</a>
+          <a class="bugreport label"
+             href="mailto:{{contact_email}}?subject=bug%20in%20{{filename}}">
+             <i class="icon-envelope icon-white"></i> Report a bug
+           </a>
+         </span>
       </div>
 
     </div>


### PR DESCRIPTION
I also moved the GitHub link over to the right side along with the mailto
link. I think that has better balance. The GitHub link looked pretty lonely
dwarfed by the CC badge.
