### PR TITLE
Added a redirect for Wordpress RSS url to /feed.xml

### DIFF
--- a/_htaccess
+++ b/_htaccess
@@ -1,4 +1,3 @@
-
 <IfModule mod_rewrite.c>
 RewriteEngine On
 RewriteBase /
@@ -48,5 +47,9 @@ RewriteRule ^(.*?)/?$ $1.html [R,L]
 # reading list 
 RewriteCond %{REQUEST_URI} ^/4_0/reading/?$
 RewriteRule ^(.*) /about/biblio.html [R,L]
+
+# Wordpress Feed URL 
+RewriteCond %{REQUEST_URI} ^/feed/?$
+RewriteRule ^(.*) /feed.xml [R,L]
 
 </IfModule>


### PR DESCRIPTION
Wordpress used to serve up the RSS feed from software-carpentry.org/feed/.  This change adds an htaccess redirect from this URL to the live feed at software-carpentry.org/feed.xml
