### PR TITLE
about/contributing: Convert Subversion -> Git in the "Teach" section

### DIFF
--- a/about/contributing.html
+++ b/about/contributing.html
@@ -24,8 +24,8 @@
 
   <dt id="teach">Teach</dt>
   <dd>
-    All of our slides, notes, and example programs are in our Subversion repository
-    at <a href="http://svn.software-carpentry.org/swc">http://svn.software-carpentry.org/swc</a>,
+    All of our slides, notes, and example programs are in our Git repository
+    at <a href="https://github.com/swcarpentry/website">https://github.com/swcarpentry/website</a>,
     and you are free to use them however you want
     (so long as you <a href="{{root_path}}/license.html">give us attribution</a>).
     Everything is designed so that individuals can work through what they need on their own,


### PR DESCRIPTION
This should have happend alongside:

  commit 0f5997401698b0c2624cf43fbce49326b9cf2c1a
 Author: Greg Wilson gvwilson@third-bit.com
 Date:   Sat Dec 15 07:03:18 2012 -0500

```
Telling potential contributors to use Git instead of Subversion
```
