### PR TITLE
Python 3 compatibility for SWC website build tools

### DIFF
--- a/bin/chars.py
+++ b/bin/chars.py
@@ -13,8 +13,9 @@ for filename in sys.argv[1:]:
     tabs = True
     for (i, line) in enumerate(lines):
         if tabs and ('\t' in line):
-            print filename, i+1, 'tab'
+            print('{0} {1} {2}'.format(filename, i+1, 'tab'))
             tabs = False
         for (j, c) in enumerate(line):
             if ord(c) > 128:
-                print filename, i+1, j+1, ord(c), '&#%x;' % ord(c)
+                print('{0} {1} {2} {3} &#{3};'.format(
+                        filename, i+1, j+1, ord(c)))

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -359,7 +359,7 @@ class GenericPage(object):
         # If anything was globbed, sort everything (including children
         # that were loaded explicitly).
         if sort:
-            self.children.sort(lambda x, y: cmp(x._sort_key, y._sort_key))
+            self.children.sort(key=lambda x: (x._sort_key, id(x)))
 
     def _finalize_children(self):
         """

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -376,7 +376,8 @@ class GenericPage(object):
         Render and save this page.
         """
         if self.app.verbosity > 0:
-            print >> sys.stderr, self.filename
+            sys.stderr.write(self.filename)
+            sys.stderr.write('\n')
 
         # Render.
         template = self.app.env.get_template(self.filename)

--- a/bin/journal.py
+++ b/bin/journal.py
@@ -74,10 +74,10 @@ def extract(filename):
 
 if __name__ == '__main__':
     assert len(sys.argv) > 1, 'Need at least one post filename'
-    print HEADER
+    print(HEADER)
     entries = [extract(filename) for filename in sys.argv[1:]]
     entries = [e for e in entries if e]
     entries.sort()
     for e in entries:
-        print e[1]
-    print FOOTER
+        print(e[1])
+    print(FOOTER)

--- a/bin/links.py
+++ b/bin/links.py
@@ -52,8 +52,12 @@ def get_links(root_dir, filenames):
     links = set()
     for f in filenames:
         doc = read_xml(f)
+        try:
+            tags = doc.findall('.//a[@href]')
+        except SyntaxError:  # ElementTree 1.2 lacks attribute XPath support
+            tags = [t for t in doc.findall('.//a') if 'href' in t.attrib]
         links.update(set(normalize(root_dir, f, r.attrib['href'])
-                         for r in doc.findall('.//a[@href]')))
+                         for r in tags))
     return set(lnk for lnk in links if lnk)  # filter out None's
 
 #-------------------------------------------------------------------------------

--- a/bin/links.py
+++ b/bin/links.py
@@ -52,9 +52,9 @@ def get_links(root_dir, filenames):
     links = set()
     for f in filenames:
         doc = read_xml(f)
-        links.update({normalize(root_dir, f, r.attrib['href'])
-                      for r in doc.findall('.//a[@href]')})
-    return {lnk for lnk in links if lnk} # filter out None's
+        links.update(set(normalize(root_dir, f, r.attrib['href'])
+                         for r in doc.findall('.//a[@href]')))
+    return set(lnk for lnk in links if lnk)  # filter out None's
 
 #-------------------------------------------------------------------------------
 
@@ -72,7 +72,7 @@ def main(root_dir):
     """
     Main command-line driver.
     """
-    filenames = {os.path.abspath(f.strip()) for f in sys.stdin}
+    filenames = set(os.path.abspath(f.strip()) for f in sys.stdin)
     links = get_links(root_dir, [f for f in filenames if f.endswith('.html')])
     show_missing(filenames, links)
 

--- a/bin/links.py
+++ b/bin/links.py
@@ -64,7 +64,7 @@ def show_missing(all_files, links):
     """
     for (source, normalized, raw) in links:
         if normalized not in all_files:
-            print '%s: %s (%s)' % (source, raw, normalized)
+            print('{0}: {1} ({2})'.format(source, raw, normalized))
 
 #-------------------------------------------------------------------------------
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -3,7 +3,10 @@ Utilities used in Software Carpentry tools.
 """
 
 import re
-import cStringIO
+try:  # Python 3
+    from io import StringIO
+except:  # Python 2
+    from cStringIO import StringIO
 import xml.etree.ElementTree as ET
 try:  # Python 3
     import html.entities
@@ -23,7 +26,7 @@ def read_xml(filename, mangle_entities=False):
             with open(filename, 'r') as reader:
                 data = reader.read()
                 data = data.replace('&', '@@@@')
-                wrapper = cStringIO.StringIO(data)
+                wrapper = StringIO(data)
                 return ET.parse(wrapper)
         else:
             with open(filename, 'r') as reader:

--- a/bin/util.py
+++ b/bin/util.py
@@ -5,7 +5,12 @@ Utilities used in Software Carpentry tools.
 import re
 import cStringIO
 import xml.etree.ElementTree as ET
-import htmlentitydefs
+try:  # Python 3
+    import html.entities
+    ENTITIES = html.entities.entitydefs
+except ImportError:  # Python 2
+    import htmlentitydefs
+    ENTITIES = htmlentitydefs.entitydefs
 
 #-------------------------------------------------------------------------------
 
@@ -24,7 +29,7 @@ def read_xml(filename, mangle_entities=False):
             with open(filename, 'r') as reader:
                 parser = ET.XMLParser()
                 parser.parser.UseForeignDTD(True)
-                parser.entity.update(htmlentitydefs.entitydefs)
+                parser.entity.update(ENTITIES)
                 return ET.parse(reader, parser=parser)
     except ET.ParseError as e:
         assert False, \

--- a/bin/util.py
+++ b/bin/util.py
@@ -8,6 +8,10 @@ try:  # Python 3
 except:  # Python 2
     from cStringIO import StringIO
 import xml.etree.ElementTree as ET
+try:  # ElementTree 1.3
+    from xml.etree.ElementTree import ParseError
+except ImportError:  # earlier versions (e.g. with Python 2.6.5)
+    from xml.parsers.expat import ExpatError as ParseError
 try:  # Python 3
     import html.entities
     ENTITIES = html.entities.entitydefs
@@ -31,10 +35,11 @@ def read_xml(filename, mangle_entities=False):
         else:
             with open(filename, 'r') as reader:
                 parser = ET.XMLParser()
-                parser.parser.UseForeignDTD(True)
+                if hasattr(parser, 'parser'):
+                    parser.parser.UseForeignDTD(True)
                 parser.entity.update(ENTITIES)
                 return ET.parse(reader, parser=parser)
-    except ET.ParseError as e:
+    except ParseError as e:
         assert False, \
                'Unable to parse {0}: {1}'.format(filename, e)
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -26,7 +26,7 @@ def read_xml(filename, mangle_entities=False):
                 parser.parser.UseForeignDTD(True)
                 parser.entity.update(htmlentitydefs.entitydefs)
                 return ET.parse(reader, parser=parser)
-    except ET.ParseError, e:
+    except ET.ParseError as e:
         assert False, \
                'Unable to parse %s: %s' % (filename, e)
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -28,7 +28,7 @@ def read_xml(filename, mangle_entities=False):
                 return ET.parse(reader, parser=parser)
     except ET.ParseError as e:
         assert False, \
-               'Unable to parse %s: %s' % (filename, e)
+               'Unable to parse {0}: {1}'.format(filename, e)
 
 #-------------------------------------------------------------------------------
 

--- a/bin/validxml.py
+++ b/bin/validxml.py
@@ -13,7 +13,7 @@ for filename in sys.argv[1:]:
         reader = open(filename, 'r')
         tree = ET.parse(reader, parser=parser)
         reader.close()
-    except ET.ParseError, e:
+    except ET.ParseError as e:
         print 'Unable to parse %s: %s' % (filename, e)
-    except Exception, e:
+    except Exception as e:
         print 'Unable to read %s: %s' % (filename, e)

--- a/bin/validxml.py
+++ b/bin/validxml.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 import sys
 import xml.etree.ElementTree as ET
-import htmlentitydefs
-
-ENTITIES = htmlentitydefs.entitydefs
+try:  # Python 3
+    import html.entities
+    ENTITIES = html.entities.entitydefs
+except ImportError:  # Python 2
+    import htmlentitydefs
+    ENTITIES = htmlentitydefs.entitydefs
 
 for filename in sys.argv[1:]:
     try:

--- a/bin/validxml.py
+++ b/bin/validxml.py
@@ -14,6 +14,6 @@ for filename in sys.argv[1:]:
         tree = ET.parse(reader, parser=parser)
         reader.close()
     except ET.ParseError as e:
-        print 'Unable to parse %s: %s' % (filename, e)
+        print('Unable to parse {0}: {1}'.format(filename, e))
     except Exception as e:
-        print 'Unable to read %s: %s' % (filename, e)
+        print('Unable to read {0}: {1}'.format(filename, e))


### PR DESCRIPTION
With these patches,

  $ make check

succeeds using Python 3.  Python 2.{6,7} should also work, but earlier
versions (e.g. Python 2.5) will choke on some newer syntax.
