### PR TITLE
iCalendar export for boot camps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ SITE = $(OUT_DIR)
 # Blog feed index.
 BLOG_RSS_FILE = $(OUT_DIR)/feed.xml
 
+# iCalendar feed
+ICALENDAR_FILE = $(OUT_DIR)/bootcamps.ics
+
 # Standard site compilation arguments.
 COMPILE = \
 	python bin/compile.py \
@@ -98,7 +101,7 @@ install :
 ## check        : rebuild entire site locally for checking purposes.
 check : $(STATIC_DST) $(OUT_DIR)/.htaccess
 	@make ascii-chars
-	$(COMPILE) -m blog/metadata.json -r $(BLOG_RSS_FILE) index.html
+	$(COMPILE) -m blog/metadata.json -r $(BLOG_RSS_FILE) -c $(ICALENDAR_FILE) index.html
 	@make blog-journal
 	@make check-links
 	@make book-figref

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -86,6 +86,11 @@ import json
 import jinja2
 import time
 import datetime
+try:  # Python 3
+    from urllib.parse import urlparse, urljoin
+except ImportError:  # Python 2
+    from urlparse import urlparse, urljoin
+
 from PyRSS2Gen import RSS2, RSSItem, Guid
 
 #----------------------------------------
@@ -134,6 +139,7 @@ class Application(object):
         self.metadata = None
         self.output_dir = None
         self.blog_filename = None
+        self.icalendar_filename = None
         self.search_path = []
         self.site = None
         self.today = None
@@ -166,7 +172,7 @@ class Application(object):
         """
         Parse command-line options.
         """
-        options, filenames = getopt.getopt(args, 'd:m:o:p:r:s:v')
+        options, filenames = getopt.getopt(args, 'd:m:o:p:r:c:s:v')
         for opt, arg in options:
             if opt == '-d':
                 self.today = arg
@@ -186,6 +192,10 @@ class Application(object):
                 assert self.blog_filename is None, \
                        'RSS filename specified multiple times'
                 self.blog_filename = arg
+            elif opt == '-c':
+                assert self.icalendar_filename is None, \
+                       'iCalendar filename specified multiple times'
+                self.icalendar_filename = arg
             elif opt == '-s':
                 self.site = arg
             elif opt == '-v':
@@ -413,12 +423,21 @@ class GenericPage(object):
 class BootCampPage(GenericPage):
     """
     Represent information about a boot camp.
+    The 'Instances' class variable keeps track of all created instances,
+    so that they can be used to render the iCalendar feed.
     """
 
     KEYS = GenericPage.KEYS + \
-           ['venue', 'date', 'startdate', 'enddate', 'eventbrite_key']
+           ['venue', 'latlng', 'date', 'startdate', 'enddate',
+            'eventbrite_key']
 
     UPLINK = 'index.html'
+
+    Instances = []
+
+    def __init__(self, *args):
+        GenericPage.__init__(self, *args)
+        BootCampPage.Instances.append(self)
 
     def _finalize_self(self):
         """
@@ -471,6 +490,13 @@ class BootCampPage(GenericPage):
         else:
             assert False, \
                    'Bad date range %s -- %s' % (start, end)
+
+    def index_link(self):
+        """
+        Link from index page to this post.
+        FIXME: must be a better way than special-casing this.
+        """
+        return 'bootcamps/{0}'.format(self.link())
 
 #----------------------------------------
 
@@ -773,6 +799,67 @@ def create_rss(filename, site, posts):
     rss.write_xml(writer)
     writer.close()
 
+
+class ICalendarWriter (object):
+    """iCalendar generator for boot camps.
+
+    The format is defined in RFC 5545.
+
+    http://tools.ietf.org/html/rfc5545
+    """
+    def __call__(self, filename, site, bootcamps):
+        lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Software Carpentry/Boot Camps//NONSGML v1.0//EN',
+            ]
+        for bootcamp in bootcamps:
+            lines.extend(self.bootcamp(site, bootcamp))
+        lines.extend([
+                'END:VCALENDAR',
+                ''])
+        content = '\r\n'.join(lines)
+        # From RFC 5545, section 3.1.4 (Character Set):
+        #   The default charset for an iCalendar stream is UTF-8
+        with open(filename, 'wb') as f:
+            f.write(content.encode('utf-8'))
+
+    def bootcamp(self, site, bootcamp):
+        uid = '{0}@{1}'.format(
+            bootcamp.link().replace('.html', ''),
+            urlparse(site).netloc or 'software-carpentry.org')
+        url = urljoin(site, bootcamp.index_link())
+        if bootcamp.enddate:
+            end_fields = [int(x) for x in bootcamp.enddate.split('-')]
+        else:  # one day boot camp?
+            end_fields = [int(x) for x in bootcamp.startdate.split('-')]
+        end = datetime.date(*end_fields)
+        dtend = end + datetime.timedelta(1)  # non-inclusive end date
+        lines = [
+            'BEGIN:VEVENT',
+            'UID:{0}'.format(uid),
+            'DTSTAMP:{0}'.format(timestamp()),
+            'DTSTART;VALUE=DATE:{0}'.format(
+                bootcamp.startdate.replace('-', '')),
+            'DTEND;VALUE=DATE:{0}'.format(dtend.strftime('%Y%m%d')),
+            'SUMMARY:{0}'.format(self.escape(
+                    '{0}, {1}'.format(bootcamp.venue, bootcamp.date))),
+            'DESCRIPTION;ALTREP="{0}":{0}'.format(url),
+            'LOCATION:{0}'.format(self.escape(bootcamp.venue)),
+            ]
+        if bootcamp.latlng:
+            lines.append('GEO:{0}'.format(bootcamp.latlng.replace(',', ';')))
+        lines.append('END:VEVENT')
+        return lines
+
+    def escape(self, value):
+        """Escape text following RFC 5545
+        """
+        for char in ['\\', ';', ',']:
+            value = value.replace(char, '\\' + char)
+        value.replace('\n', '\\n')
+        return value
+
 #----------------------------------------
 
 def main(args):
@@ -790,6 +877,9 @@ def main(args):
         page.render()
     if app.blog_filename:
         create_rss(app.blog_filename, app.site, BlogPostPage.Instances)
+    if app.icalendar_filename:
+        icw = ICalendarWriter()
+        icw(app.icalendar_filename, app.site, BootCampPage.Instances)
 
 #----------------------------------------
 

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -111,6 +111,12 @@ BLOG_TAG_REPLACEMENT_PATTERN = re.compile(r'<[^>]+>')
 
 #----------------------------------------
 
+def timestamp():
+    """Return the current UTC time formatted in ISO 8601
+    """
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+
+
 class Application(object):
     """
     Manage the application:
@@ -147,12 +153,11 @@ class Application(object):
             root_path = '.'
         else:
             root_path = '/'.join([os.pardir] * depth)
-        timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
         return {'contact_email' : CONTACT_EMAIL,
                 'filename'      : filename,
                 'root_path'     : root_path,
                 'site'          : self.site,
-                'timestamp'     : timestamp,
+                'timestamp'     : timestamp(),
                 'today'         : self.today,
                 'twitter_name'  : TWITTER_NAME,
                 'twitter_url'   : TWITTER_URL}

--- a/bootcamps/2011-11-toronto.html
+++ b/bootcamps/2011-11-toronto.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2011" />
   <meta name="startdate" content="2011-11-07" />
   <meta name="enddate" content="2011-11-08" />
+  <meta name="latlng" content="43.661476,-79.395189" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Software Carpentry is teaming up with <a title="Scinet" href="http://www.scinethpc.ca/about-scinet/" target="_blank">Scinet</a> and <a title="The Hacker Within" href="http://hackerwithin.org/thw/">The Hacker Within</a> to host a 2 day workshop on software engineering at the University of Toronto for graduate students in the sciences. The workshop is sold out, but we'll be posting all of our course materials here for anyone who wants to use them.</p>

--- a/bootcamps/2012-01-stsci.html
+++ b/bootcamps/2012-01-stsci.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2012" />
   <meta name="startdate" content="2012-01-18" />
   <meta name="enddate" content="2012-01-19" />
+  <meta name="latlng" content="39.332604,-76.62319" />
 {% endblock file_metadata %}
 {% block content %}
 <p>The main aim of this two-day workshop is to make sure everyone has the skills needed to tackle the material we'll be covering online over the next 5-6 weeks. Based on your responses to our survey, our schedule will be:</p>

--- a/bootcamps/2012-02-itcp.html
+++ b/bootcamps/2012-02-itcp.html
@@ -4,6 +4,7 @@
   <meta name="date" content="February 2012" />
   <meta name="startdate" content="2012-02-20" />
   <meta name="enddate" content="2012-03-02" />
+  <meta name="latlng" content="45.703255,13.718013" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Software Carpentry is teaming up with the International Centre for Theoretical Physics in Trieste, Italy to hold a 2-week workshop on Scientific Software Development. The majority of the participants for this course are from developing countries.</p>

--- a/bootcamps/2012-02-toronto.html
+++ b/bootcamps/2012-02-toronto.html
@@ -4,6 +4,7 @@
   <meta name="date" content="February 2012" />
   <meta name="startdate" content="2012-02-23" />
   <meta name="enddate" content="2012-02-24" />
+  <meta name="latlng" content="43.661476,-79.395189" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>When:</strong> February 23-24, 2012. 9am to 5pm.</p>

--- a/bootcamps/2012-03-indiana.html
+++ b/bootcamps/2012-03-indiana.html
@@ -4,6 +4,7 @@
   <meta name="date" content="March 2012" />
   <meta name="startdate" content="2012-03-07" />
   <meta name="enddate" content="2012-03-08" />
+  <meta name="latlng" content="39.1663815,-86.526621" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>When:</strong> March 7-8, 2012. 9am to 5pm.</p>

--- a/bootcamps/2012-03-mbari.html
+++ b/bootcamps/2012-03-mbari.html
@@ -4,6 +4,7 @@
   <meta name="date" content="March 2012" />
   <meta name="startdate" content="2012-03-26" />
   <meta name="enddate" content="2012-03-27" />
+  <meta name="latlng" content="36.802151,-121.788163" />
 {% endblock file_metadata %}
 {% block content %}
 <ul>

--- a/bootcamps/2012-03-nersc.html
+++ b/bootcamps/2012-03-nersc.html
@@ -4,6 +4,7 @@
   <meta name="date" content="March 2012" />
   <meta name="startdate" content="2012-03-28" />
   <meta name="enddate" content="2012-03-29" />
+  <meta name="latlng" content="37.8083814,-122.2675787" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Please download experiments.db.</p>

--- a/bootcamps/2012-04-chicago.html
+++ b/bootcamps/2012-04-chicago.html
@@ -4,6 +4,7 @@
   <meta name="date" content="April 2012" />
   <meta name="startdate" content="2012-04-02" />
   <meta name="enddate" content="2012-04-03" />
+  <meta name="latlng" content="41.7901128,-87.6007318" />
 {% endblock file_metadata %}
 {% block content %}
 <p>

--- a/bootcamps/2012-04-ucl.html
+++ b/bootcamps/2012-04-ucl.html
@@ -4,6 +4,7 @@
   <meta name="date" content="April-May 2012" />
   <meta name="startdate" content="2012-04-30" />
   <meta name="enddate" content="2012-05-01" />
+  <meta name="latlng" content="51.5598815,-0.1334579" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>This course is now fully booked and has a long waiting list. If you would like to be informed of similar events in the future, please e-mail us on swc2012@ucl.ac.uk.</strong></p>

--- a/bootcamps/2012-04-utahstate.html
+++ b/bootcamps/2012-04-utahstate.html
@@ -4,6 +4,7 @@
   <meta name="date" content="April 2012" />
   <meta name="startdate" content="2012-04-14" />
   <meta name="enddate" content="2012-04-15" />
+  <meta name="latlng" content="41.7449488,-111.8042944" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Please download:</p>

--- a/bootcamps/2012-05-alberta.html
+++ b/bootcamps/2012-05-alberta.html
@@ -4,6 +4,7 @@
   <meta name="date" content="May 2012" />
   <meta name="startdate" content="2012-05-16" />
   <meta name="enddate" content="2012-05-17" />
+  <meta name="latlng" content="53.5234543,-113.5259951" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Starting point for homework</strong></p>

--- a/bootcamps/2012-05-michiganstate.html
+++ b/bootcamps/2012-05-michiganstate.html
@@ -4,6 +4,7 @@
   <meta name="date" content="May 2012" />
   <meta name="startdate" content="2012-05-07" />
   <meta name="enddate" content="2012-05-08" />
+  <meta name="latlng" content="42.7272884,-84.482106" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Database file</strong>: experiments.db</p>

--- a/bootcamps/2012-05-newcastle.html
+++ b/bootcamps/2012-05-newcastle.html
@@ -4,6 +4,7 @@
   <meta name="date" content="May 2012" />
   <meta name="startdate" content="2012-05-14" />
   <meta name="enddate" content="2012-05-15" />
+  <meta name="latlng" content="54.980095,-1.6146142" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>This course is now fully booked and has a long waiting list. If you would like to be informed of similar events in the future, please e-mail us on <a href="mailto:swc2012@ncl.ac.uk">swc2012@ncl.ac.uk</a>.</strong></p>

--- a/bootcamps/2012-05-ubc.html
+++ b/bootcamps/2012-05-ubc.html
@@ -4,6 +4,7 @@
   <meta name="date" content="May 2012" />
   <meta name="startdate" content="2012-05-22" />
   <meta name="enddate" content="2012-05-23" />
+  <meta name="latlng" content="49.2617149,-123.2534305" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Some Basic Commands</strong></p>

--- a/bootcamps/2012-06-inria.html
+++ b/bootcamps/2012-06-inria.html
@@ -4,6 +4,7 @@
   <meta name="date" content="June 2012" />
   <meta name="startdate" content="2012-06-28" />
   <meta name="enddate" content="2012-06-29" />
+  <meta name="latlng" content="48.831673,2.355623" />
 {% endblock file_metadata %}
 {% block content %}
 <p><img src="{{root_path}}/files/2012/03/7pj1-212x300.png" /></p>

--- a/bootcamps/2012-06-jhu.html
+++ b/bootcamps/2012-06-jhu.html
@@ -4,6 +4,7 @@
   <meta name="date" content="June 2012" />
   <meta name="startdate" content="2012-06-18" />
   <meta name="enddate" content="2012-06-19" />
+  <meta name="latlng" content="39.3275798,-76.6207579" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Room 475, Bloomberg Center for Physics &amp; Astronomy, Johns Hopkins University</p>

--- a/bootcamps/2012-07-halifax.html
+++ b/bootcamps/2012-07-halifax.html
@@ -4,6 +4,7 @@
   <meta name="date" content="July 2012 " />
   <meta name="startdate" content="2012-07-16" />
   <meta name="enddate" content="2012-07-17" />
+  <meta name="latlng" content="44.6322608,-63.5802627" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Rm 255, Sobey Building, Saint Mary's University, Halifax, Nova Scotia.</p>

--- a/bootcamps/2012-07-mit.html
+++ b/bootcamps/2012-07-mit.html
@@ -4,6 +4,7 @@
   <meta name="date" content="July 2012" />
   <meta name="startdate" content="2012-07-09" />
   <meta name="enddate" content="2012-07-10" />
+  <meta name="latlng" content="42.3591326,-71.093201" />
 {% endblock file_metadata %}
 {% block content %}
 <p><a href="http://www.nap.edu/catalog.php?record_id=9853"><em>How People Learn</em></a></p>

--- a/bootcamps/2012-07-utsc.html
+++ b/bootcamps/2012-07-utsc.html
@@ -4,6 +4,7 @@
   <meta name="date" content="July 2012" />
   <meta name="startdate" content="2012-07-19" />
   <meta name="enddate" content="2012-07-20" />
+  <meta name="latlng" content="43.7835514,-79.1863972" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Starting point for July 31 tutorial</p>

--- a/bootcamps/2012-07-waterloo.html
+++ b/bootcamps/2012-07-waterloo.html
@@ -4,6 +4,7 @@
   <meta name="date" content="July 2012" />
   <meta name="startdate" content="2012-07-12" />
   <meta name="enddate" content="2012-07-13" />
+  <meta name="latlng" content="43.4701302,-80.5357712" />
   <meta name="eventbrite_key" content="3558725243" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-09-columbia.html
+++ b/bootcamps/2012-09-columbia.html
@@ -4,6 +4,7 @@
   <meta name="date" content="September 2012" />
   <meta name="startdate" content="2012-09-28" />
   <meta name="enddate" content="2012-09-29" />
+  <meta name="latlng" content="40.8080777,-73.9635678" />
 {% endblock file_metadata %}
 {% block content %}
 <p>Data:</p>

--- a/bootcamps/2012-09-dafx.html
+++ b/bootcamps/2012-09-dafx.html
@@ -4,6 +4,7 @@
   <meta name="date" content="September 2012" />
   <meta name="startdate" content="2012-09-13" />
   <meta name="enddate" content="2012-09-14" />
+  <meta name="latlng" content="53.9481933,-1.0529144" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> DAFx Conference, University of York.</p>

--- a/bootcamps/2012-09-oslo.html
+++ b/bootcamps/2012-09-oslo.html
@@ -4,6 +4,7 @@
   <meta name="date" content="September 2012" />
   <meta name="startdate" content="2012-09-17" />
   <meta name="enddate" content="2012-09-18" />
+  <meta name="latlng" content="59.9399586,10.7217496" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Room 3213, Kristine Bonnevies hus, Blindernveien 31, University of Oslo. (Map: http://www.uio.no/om/finn-fram/omrader/blindern/bl18/) If you are using public transport, take T-bane (subway) lines 3 (towards Sognsvann), 4 (Ringen) or 5 (Storo) from the city central ("Jernbanetorget" close to the central train station), Nationaltheatret or Majorstuen, exit at Blindern station. It's a 6-7 minute walk from there.</p>

--- a/bootcamps/2012-10-caltech.html
+++ b/bootcamps/2012-10-caltech.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-23" />
   <meta name="enddate" content="2012-10-24" />
+  <meta name="latlng" content="34.141411,-118.1249" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> 383 Hill Annex, Caltech Campus, Pasadena, CA 91125.</p>

--- a/bootcamps/2012-10-gmu.html
+++ b/bootcamps/2012-10-gmu.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-25" />
   <meta name="enddate" content="2012-10-26" />
+  <meta name="latlng" content="38.831513,-77.308746" />
   <meta name="eventbrite_key" content="4647209930" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-10-lbl.html
+++ b/bootcamps/2012-10-lbl.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-17" />
   <meta name="enddate" content="2012-10-18" />
+  <meta name="latlng" content="37.8759281,-122.2500418" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Lawrence Berkeley National Laboratory, Building 50A, Room 5132</p>

--- a/bootcamps/2012-10-newcastle.html
+++ b/bootcamps/2012-10-newcastle.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-22" />
   <meta name="enddate" content="2012-10-23" />
+  <meta name="latlng" content="54.980095,-1.6146142" />
 {% endblock file_metadata %}
 {% block content %}
 <p>The University of Newcastle is running a Software Carpentry boot camp on October 22-23, 2012. For more information, or to register, please see <a href="http://digitalinstitute.ncl.ac.uk/software_carpentry">their web site</a>.</p>

--- a/bootcamps/2012-10-oxford.html
+++ b/bootcamps/2012-10-oxford.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-30" />
   <meta name="enddate" content="2012-10-31" />
+  <meta name="latlng" content="51.7571373,-1.2569052" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>When:</strong> Oct 30 - Oct 31, 2012. 9am to 5pm.</p>

--- a/bootcamps/2012-10-purdue.html
+++ b/bootcamps/2012-10-purdue.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-08" />
   <meta name="enddate" content="2012-10-09" />
+  <meta name="latlng" content="40.4282668,-86.9143245" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Purdue University (currently scheduled for Stewart Center, Room 318).</p>

--- a/bootcamps/2012-10-ubc.html
+++ b/bootcamps/2012-10-ubc.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-18" />
   <meta name="enddate" content="2012-10-19" />
+  <meta name="latlng" content="49.2617149,-123.2534305" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>New!</strong> <a href="#install">Setup instructions</a> have been added to this page. Please make sure you go through them the day before the workshop starts, and <a href="mailto:{{contact_email}}">mail us</a> if you have problems.</p>

--- a/bootcamps/2012-10-ucb.html
+++ b/bootcamps/2012-10-ucb.html
@@ -4,6 +4,7 @@
   <meta name="date" content="October 2012" />
   <meta name="startdate" content="2012-10-20" />
   <meta name="enddate" content="2012-10-21" />
+  <meta name="latlng" content="37.8695,-122.258949" />
   <meta name="eventbrite_key" content="3942004642" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-11-hawaii.html
+++ b/bootcamps/2012-11-hawaii.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2012" />
   <meta name="startdate" content="2012-11-30" />
   <meta name="enddate" content="2012-12-01" />
+  <meta name="latlng" content="21.3006615,-157.8191655" />
   <meta name="eventbrite_key" content="4314420548" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-11-mcmaster.html
+++ b/bootcamps/2012-11-mcmaster.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2012" />
   <meta name="startdate" content="2012-11-08" />
   <meta name="enddate" content="2012-11-09" />
+  <meta name="latlng" content="43.2613285,-79.9202476" />
   <meta name="eventbrite_key" content="4522284274" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-11-scripps.html
+++ b/bootcamps/2012-11-scripps.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2012" />
   <meta name="startdate" content="2012-11-15" />
   <meta name="enddate" content="2012-11-16" />
+  <meta name="latlng" content="32.8953297,-117.2421882" />
   <meta name="eventbrite_key" content="3869222950" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-11-unc.html
+++ b/bootcamps/2012-11-unc.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2012" />
   <meta name="startdate" content="2012-11-28" />
   <meta name="enddate" content="2012-11-29" />
+  <meta name="latlng" content="34.2274248,-77.8791793" />
   <meta name="eventbrite_key" content="4224585850" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-11-wustl.html
+++ b/bootcamps/2012-11-wustl.html
@@ -4,6 +4,7 @@
   <meta name="date" content="November 2012" />
   <meta name="startdate" content="2012-11-10" />
   <meta name="enddate" content="2012-11-11" />
+  <meta name="latlng" content="38.6480562,-90.3050959" />
   <meta name="eventbrite_key" content="4262808174" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2012-12-edinburgh.html
+++ b/bootcamps/2012-12-edinburgh.html
@@ -4,6 +4,7 @@
   <meta name="date" content="December 2012" />
   <meta name="startdate" content="2012-12-04" />
   <meta name="enddate" content="2012-12-05" />
+  <meta name="latlng" content="55.9453279,-3.1911838" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> University of Edinburgh.</p>

--- a/bootcamps/2012-12-uta.html
+++ b/bootcamps/2012-12-uta.html
@@ -4,6 +4,7 @@
   <meta name="date" content="December 2012" />
   <meta name="startdate" content="2012-12-10" />
   <meta name="enddate" content="2012-12-11" />
+  <meta name="latlng" content="30.2835989,-97.7344283" />
   <meta name="eventbrite_key" content="3666777430" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-chicago.html
+++ b/bootcamps/2013-01-chicago.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-12" />
   <meta name="enddate" content="2013-01-13" />
+  <meta name="latlng" content="41.7901128,-87.6007318" />
   <meta name="eventbrite_key" content="4044017766" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-mcgill.html
+++ b/bootcamps/2013-01-mcgill.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-12" />
   <meta name="enddate" content="2013-01-13" />
+  <meta name="latlng" content="45.4174172,-73.9489284" />
   <meta name="eventbrite_key" content="4859419655" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-vt.html
+++ b/bootcamps/2013-01-vt.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-31" />
   <meta name="enddate" content="2013-02-01" />
+  <meta name="latlng" content="37.2283843,-80.4234167" />
   <meta name="eventbrite_key" content="4444112460" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-waterloo.html
+++ b/bootcamps/2013-01-waterloo.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-12" />
   <meta name="enddate" content="2013-01-13" />
+  <meta name="latlng" content="43.4691285,-80.5398649" />
   <meta name="eventbrite_key" content="4455642948" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-02-macquarie.html
+++ b/bootcamps/2013-02-macquarie.html
@@ -4,6 +4,7 @@
   <meta name="date" content="February 2013" />
   <meta name="startdate" content="2013-02-07" />
   <meta name="enddate" content="2013-02-08" />
+  <meta name="latlng" content="-33.773636,151.112005" />
   <meta name="eventbrite_key" content="4114901782" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-02-uwash.html
+++ b/bootcamps/2013-02-uwash.html
@@ -4,6 +4,7 @@
   <meta name="date" content="February 2013" />
   <meta name="startdate" content="2013-02-25" />
   <meta name="enddate" content="2013-02-26" />
+  <meta name="latlng" content="47.655965,-122.309377" />
   <meta name="eventbrite_key" content="4309568034" />
 {% endblock file_metadata %}
 {% block content %}


### PR DESCRIPTION
Broken off from #21 [1](https://github.com/swcarpentry/website/issues/21).

Because this functionality is similar to the RSS feed for blog posts,
I mimicked that implementation and wrote the generator into
compile.py.
