### PR TITLE
added a reference to the swcarpentry.github chicago requirements page.

### DIFF
--- a/bootcamps/2013-01-chicago.html
+++ b/bootcamps/2013-01-chicago.html
@@ -8,11 +8,11 @@
   <meta name="eventbrite_key" content="4044017766" />
 {% endblock file_metadata %}
 {% block content %}
-<p><strong>Where:</strong> University of Chicago.</p>
-<p><strong>When:</strong> January 19-20, 2013. We will start at 9:00 and end at 4:30 each day.</p>
+<p><strong>Where:</strong> University of Chicago. Kent Hall, Room 120.</p>
+<p><strong>When:</strong> January 12-13, 2013. We will start at 9:00 and end at 4:30 each day.</p>
 {% include "_what.html" %}
 {% include "_who.html" %}
-{% include "_requirements.html" %}
+<p><strong>Requirements:</strong> Visit the <a href="http://swcarpentry.github.com/boot-camps/2013-01-12-chicago/">bootcamp web page</a> for installation instructions and schedule information.</p>
 {% include "_content.html" %}
 {% include "_contact.html" %}
 {{eventbrite(page.eventbrite_key, page.venue, page.date)}}


### PR DESCRIPTION
This is very minor and only affects the Uchicago bootcamp page. It adds a link to the setup page in the boot-camps repo, and fixes the date, which still said 19-20, but should be 12-13.

I'm not sure whether the swcarpentry ettiquette/protocol calls for this to be a pull request, but I tend to think even minor changes should be looked over by at least one other person, so I'll do it this way. Of course let me know if you guys think I should just push minor things like this in the future.
