### PR TITLE
compile.py: Add URL entry to the iCalendar feed

### DIFF
--- a/bin/compile.py
+++ b/bin/compile.py
@@ -832,6 +832,7 @@ class ICalendarWriter(object):
             'SUMMARY:{0}'.format(self.escape(
                     '{0}, {1}'.format(bootcamp.venue, bootcamp.date))),
             'DESCRIPTION;ALTREP="{0}":{0}'.format(url),
+            'URL:{0}'.format(url),
             'LOCATION:{0}'.format(self.escape(bootcamp.venue)),
         ]
         if bootcamp.latlng:


### PR DESCRIPTION
From RFC 5545, section 3.8.4.6:

  Purpose: This property defines a Uniform Resource Locator (URL)
  associated with the iCalendar object.
  ...
  Description: This property may be used in a calendar component to
  convey a location where a more dynamic rendition of the calendar
  information associated with the calendar component can be found.
  This memo does not attempt to standardize the form of the URI, nor
  the format of the resource pointed to by the property value.

The RFC examples point to ifb (free or busy time) and ics (arbitrary
scheduling) files, but Jon Udell suggested we could use it for boot
camp homepages too:

On Thu, Dec 20, 2012 at 08:58:18PM +0000, Jon Udell wrote:

> The one thing I'd add would be to populate the URL property with the
> most specific URL for each event.

He suggested this in addition to our current DESCRIPTION:

On Thu, Dec 20, 2012 at 09:06:06PM +0000, Jon Udell wrote:

> I see that there are already per-event URLs provided as the
> DESCRIPTION. For what it's worth, from my POV it would make sense to
> also do this:
> 
> URL:http://software-carpentry.org/bootcamps/2012-09-dafx.html
