### PR TITLE
Template variables not expanded in blog/index.html

### DIFF
--- a/_base.html
+++ b/_base.html
@@ -2,16 +2,7 @@
 <html>
 <!-- pageclass: GenericPage -->
 
-{% macro youtube(title, stem, time) -%}
-  <div class="youtube">
-    <iframe title="{{title}}"
-            src="http://www.youtube.com/embed/{{stem}}"
-            time="{{time}}"
-            width="640" height="506"
-            frameborder="0"
-            allowfullscreen="allowfullscreen"></iframe>
-  </div>
-{%- endmacro %}
+{% from '_content_macros.html' import youtube %}
 
 {% macro nav_left() -%}
   {% if page.prev %}

--- a/_content_macros.html
+++ b/_content_macros.html
@@ -1,0 +1,12 @@
+<!-- Macros for use in page content -->
+
+{% macro youtube(title, stem, time) -%}
+  <div class="youtube">
+    <iframe title="{{title}}"
+            src="http://www.youtube.com/embed/{{stem}}"
+            time="{{time}}"
+            width="640" height="506"
+            frameborder="0"
+            allowfullscreen="allowfullscreen"></iframe>
+  </div>
+{%- endmacro %}

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -684,10 +684,14 @@ class BlogPostPage(GenericPage):
         m = BLOG_CONTENT_PATTERN.search(self._block)
         if m:
             self.content = m.group(1)
+            content = '\n'.join([
+                    "{% from '_content_macros.html' import youtube %}",
+                    self.content,
+                    ])
+            template = self.app.env.from_string(content)
             template_vars = self.app.standard(self.filename)
             template_vars['root_path'] = self.app.site
-            self.rendered_content = jinja2.Template(self.content).render(
-                **template_vars)
+            self.rendered_content = template.render(page=self, **template_vars)
 
         for key in self.app.metadata:
             if key not in self.__dict__:


### PR DESCRIPTION
bin/compile.py creates blog/index.html by stitching together the content of recent blog posts. However, the template variables in those fragments (such as {{root_path}}) are not being expanded, so links in blog/index.html are broken.
