### PR TITLE
bootcamps: Add latlng metadata to several bootcamps

### DIFF
--- a/bootcamps/2013-01-CAMH.html
+++ b/bootcamps/2013-01-CAMH.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-24" />
   <meta name="enddate" content="2013-01-25" />
+  <meta name="latlng" content="43.6471184,-79.3942998" />
   <meta name="eventbrite_key" content="5086301264" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-columbia.html
+++ b/bootcamps/2013-01-columbia.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-30" />
   <meta name="enddate" content="2013-02-02" />
+  <meta name="latlng" content="40.8080777,-73.9635678" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Columbia University</p>

--- a/bootcamps/2013-01-tuebingen.html
+++ b/bootcamps/2013-01-tuebingen.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-25" />
   <meta name="enddate" content="2013-01-26" />
+  <meta name="latlng" content="48.5369804,9.058935" />
   <meta name="eventbrite_key" content="5014203618" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-tum.html
+++ b/bootcamps/2013-01-tum.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-22" />
   <meta name="enddate" content="2013-01-23" />
+  <meta name="latlng" content="48.264934,11.669121" />
   <meta name="eventbrite_key" content="4602466100" />
 {% endblock file_metadata %}
 {% block content %}

--- a/bootcamps/2013-01-ubc-r-advanced.html
+++ b/bootcamps/2013-01-ubc-r-advanced.html
@@ -4,6 +4,7 @@
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-21" />
   <meta name="enddate" content="2013-01-22" />
+  <meta name="latlng" content="49.2617149,-123.2534305" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> MSL 101, University of British Columbia.</p>

--- a/bootcamps/2013-01-ubc-r-beginners.html
+++ b/bootcamps/2013-01-ubc-r-beginners.html
@@ -3,6 +3,7 @@
   <meta name="venue" content="University of British Columbia" />
   <meta name="date" content="January 2013" />
   <meta name="startdate" content="2013-01-11" />
+  <meta name="latlng" content="49.2617149,-123.2534305" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> MSL 101, University of British Columbia.</p>

--- a/bootcamps/2013-02-amos.html
+++ b/bootcamps/2013-02-amos.html
@@ -4,6 +4,7 @@
   <meta name="date" content="February 2013" />
   <meta name="startdate" content="2013-02-14" />
   <meta name="enddate" content="2013-02-15" />
+  <meta name="latlng" content="-37.8253285,144.9516212" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> <a href="http://www.amos.org.au/events/id/92/title/AMOS%20National%20Conference%2011-13%20February%202013%20-%20Melbourne">AMOS National Conference</a>, Melbourne.</p>

--- a/bootcamps/2013-03-utahstate.html
+++ b/bootcamps/2013-03-utahstate.html
@@ -4,6 +4,7 @@
   <meta name="date" content="March 2013" />
   <meta name="startdate" content="2013-03-23" />
   <meta name="enddate" content="2013-03-24" />
+  <meta name="latlng" content="41.7449488,-111.8042944" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Utah State University.</p>

--- a/bootcamps/2013-03-virginia.html
+++ b/bootcamps/2013-03-virginia.html
@@ -4,6 +4,7 @@
   <meta name="date" content="March 2013" />
   <meta name="startdate" content="2013-03-07" />
   <meta name="enddate" content="2013-03-08" />
+  <meta name="latlng" content="38.031441,-78.499356" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> University of Virginia.</p>

--- a/bootcamps/2013-04-arizona.html
+++ b/bootcamps/2013-04-arizona.html
@@ -4,6 +4,7 @@
   <meta name="date" content="April 2013" />
   <meta name="startdate" content="2013-04-04" />
   <meta name="enddate" content="2013-04-05" />
+  <meta name="latlng" content="32.2363584,-110.9495396" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> University of Arizona.</p>

--- a/bootcamps/2013-04-manchester.html
+++ b/bootcamps/2013-04-manchester.html
@@ -4,6 +4,7 @@
   <meta name="date" content="April 2013" />
   <meta name="startdate" content="2013-04-18" />
   <meta name="enddate" content="2013-04-19" />
+  <meta name="latlng" content="53.4783491,-2.2416052" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> University of Manchester.</p>

--- a/bootcamps/2013-07-bath.html
+++ b/bootcamps/2013-07-bath.html
@@ -4,6 +4,7 @@
   <meta name="date" content="July 2013" />
   <meta name="startdate" content="2013-07-15" />
   <meta name="enddate" content="2013-07-16" />
+  <meta name="latlng" content="51.3777431,-2.3263779" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> University of Bath.</p>


### PR DESCRIPTION
I don't have any personal connection to these boot camps, so I mostly used
the location of the hosting university.  Some of these boot camps actually
list addresses (e.g. 2013-01-CAMH) or link to pages that do
(e.g. 2013-02-amos), and I used that location to get more accurate 
coordinates where possible.
