### PR TITLE
Remove dates from calendar event summaries

### DIFF
--- a/bin/compile.py
+++ b/bin/compile.py
@@ -832,8 +832,7 @@ class ICalendarWriter(object):
             'DTSTAMP:{0}'.format(timestamp()),
             'DTSTART;VALUE=DATE:{0}'.format(bootcamp.startdate.replace('-', '')),
             'DTEND;VALUE=DATE:{0}'.format(dtend.strftime('%Y%m%d')),
-            'SUMMARY:{0}'.format(self.escape(
-                    '{0}, {1}'.format(bootcamp.venue, bootcamp.date))),
+            'SUMMARY:{0}'.format(self.escape(bootcamp.venue)),
             'DESCRIPTION;ALTREP="{0}":{0}'.format(url),
             'URL:{0}'.format(url),
             'LOCATION:{0}'.format(self.escape(bootcamp.venue)),


### PR DESCRIPTION
The events in http://software-carpentry.org/bootcamps.ics have the date in their `SUMMARY` field, e.g. `SUMMARY:University of Oslo\, Sep 17-18\, 2012`. The summary field is used in the embedded Google calendar and the date adds a lot of text and makes it look crowded. This is on a calendar so it shouldn't be necessary to repeat the date in the summary.

![Screen Shot 2012-12-29 at 11 12 49 PM](https://f.cloud.github.com/assets/920492/35637/cb3e52f4-5237-11e2-99e7-04e311474679.png)
