### PR TITLE
.mailmap: Standardize identifiers for Cait, Jon, and Matt

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Cait Pickens <picken19@msu.edu> <picken19@msu.edu>
+Jon Pipitone <jon.pipitone@gmail.com> <jon.pipitone@gmail.com>
+Jon Pipitone <jon.pipitone@gmail.com> <jon.pipitone@utoronto.ca>
+Matt Davis <jiffyclub@gmail.com> <jiffyclub.programatic@gmail.com>
+Matt Davis <jiffyclub@gmail.com> <jiffyclub@gmail.com>


### PR DESCRIPTION
This makes it easier to see who's contributed:

  $ git log --pretty='format:%aN <%aE>' | sort | uniq

without double-counting people with inconsistent Git IDs.

For additional motivation, see swcarpentry/boot-camps#9.
