### PR TITLE
bootcamps/index.html: Add a 'calendar' ID to the calendar <p>

### DIFF
--- a/bootcamps/index.html
+++ b/bootcamps/index.html
@@ -121,7 +121,7 @@ attendees to have an enjoyable and fulfilling experience.</p>
 
 <div id="map_canvas" style="width: 98%; height: 500px; margin-left:auto; margin-right: auto; margin-bottom: 25px;"></div>
 
-<p>
+<p id="calendar">
   <iframe src="https://www.google.com/calendar/embed?title=Boot%20Camps&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=500&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=efjc2eea4qegtctcrg6kc0nrba9i0rbg%40import.calendar.google.com&amp;color=%232952A3&amp;ctz=America%2FNew_York"
           style=" border-width:0 "
           width="98%"

--- a/index.html
+++ b/index.html
@@ -72,7 +72,8 @@
       more done in less time: program construction, version control,
       testing, the command line, and data management. Short lessons
       alternate with hands-on practical sessions for two full days.
-      Check out <a href="{{root_path}}/bootcamps/index.html">our calendar</a>
+      Check out
+      <a href="{{root_path}}/bootcamps/index.html#calendar">our calendar</a>
       to find a boot camp near you.
     </p>
 


### PR DESCRIPTION
This allows more direct linking, e.g. from the root index.html.
