### PR TITLE
about/team.html: Make CNERG reference a live URL

### DIFF
--- a/about/team.html
+++ b/about/team.html
@@ -226,7 +226,7 @@
 
 <div class="media">
   <img class="media-object pull-left" src="{{root_path}}/img/people/wilson-paul.jpg" alt="Paul Wilson" />
-  <div id="wilson.p" class="media-body"><a href="http://cnerg.github.com/"><span class="person">Paul Wilson</span></a> is an Associate Professor at the U. Wisconsin-Madison where he teaches nuclear engineering.  His research group, CNERG [cnerg.github.com], delivers new capability for the simulation of nuclear systems.  The Hacker Within was born from his research group as he tried to impart Software Carpentry skills upon his graduate students. </div>
+  <div id="wilson.p" class="media-body"><a href="http://cnerg.github.com/"><span class="person">Paul Wilson</span></a> is an Associate Professor at the U. Wisconsin-Madison where he teaches nuclear engineering.  His research group, <a href="http://cnerg.github.com">CNERG</a>, delivers new capability for the simulation of nuclear systems.  The Hacker Within was born from his research group as he tried to impart Software Carpentry skills upon his graduate students. </div>
 </div>
 
 <h2 id="support">Support</h2>


### PR DESCRIPTION
It currently looks like a broken Markdown link :p.
