### PR TITLE
Credit website authors in an auto-generated AUTHORS file.

### DIFF
--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -1,0 +1,45 @@
+[project]
+name: SWC Website
+vcs: Git
+
+[files]
+authors: yes
+files: no
+
+[author-hacks]
+# Not actually README authors, but I'm too lazy to sort out the old
+# SVN/author situation for commits that weren't converted to Git.
+# Even http://svn.software-carpentry.org only goes back to 2009, where
+# it was moved without history from http://swc.scipy.org/svn/All.
+# Feel free to trim this as the old authors make commits to the new
+# repository.
+README.md: ad |
+	ainsley |
+	amgrubb |
+	arbrown |
+	Dhavide Aruliah <dhavide@gmail.com> |
+	babalex |
+	Azalee Bostroem <bostroem@stsci.edu> |
+	buske |
+	C. Titus Brown <ctb@msu.edu> |
+	echeran |
+	Ethan White <ethan@weecology.org> |
+	fpitt |
+	ilya |
+	Justin Kitzes <jkitzes@berkeley.edu> |
+	jmontojo |
+	kenbauer |
+	lmds |
+	luis |
+	Ian Mitchell <mitchell@cs.ubc.ca> |
+	Neil Chue Hong <N.ChueHong@software.ac.uk> |
+	noam |
+	paullu |
+	pgries |
+	Paul Wilson <wilsonp@engr.wisc.edu> |
+	reid |
+	rtulk |
+	shaddock |
+	tavish |
+	tommy |
+	zuzelvp

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,45 @@
+SWC Website was written by:
+Anthony Scopatz <scopatz@gmail.com>
+Azalee Bostroem <bostroem@stsci.edu>
+C. Titus Brown <ctb@msu.edu>
+Cait Pickens <picken19@msu.edu>
+Caitlyn <picken19@msu.edu>
+Dhavide Aruliah <dhavide@gmail.com>
+Ethan White <ethan@weecology.org>
+Greg Wilson <gvwilson@third-bit.com>
+Ian Mitchell <mitchell@cs.ubc.ca>
+Jon Pipitone <jon.pipitone@gmail.com>
+Jon Pipitone <jon.pipitone@utoronto.ca>
+Justin Kitzes <jkitzes@berkeley.edu>
+Karthik Ram <karthik.ram@gmail.com>
+Katy Huff <katyhuff@gmail.com>
+Matt <jiffyclub.programatic@gmail.com>
+Matt <jiffyclub@gmail.com>
+Matt Davis <jiffyclub@gmail.com>
+Neil Chue Hong <N.ChueHong@software.ac.uk>
+Nicolas Limare <nicolas.limare@cmla.ens-cachan.fr>
+Paul Wilson <wilsonp@engr.wisc.edu>
+W. Trevor King <wking@tremily.us>
+ad
+ainsley
+amgrubb
+arbrown
+babalex
+buske
+echeran
+fpitt
+ilya
+jmontojo
+kenbauer
+lmds
+luis
+noam
+paullu
+pgries
+pipitone <jon.pipitone@gmail.com>
+reid
+rtulk
+shaddock
+tavish
+tommy
+zuzelvp

--- a/license.html
+++ b/license.html
@@ -20,7 +20,7 @@
 <p>Under the following conditions:</p>
 <ul>
   <li>
-    <strong>Attribution</strong>&mdash;You must attribute the work using "Copyright &copy; Software Carpentry" (but not in any way that suggests that we endorse you or your use of the work).  Where practical, you must also include a hyperlink to http://software-carpentry.org.
+    <strong>Attribution</strong>&mdash;You must attribute the work using "Copyright &copy; Software Carpentry" (but not in any way that suggests that we endorse you or your use of the work).  Where practical, you must also include a hyperlink to <a href="http://software-carpentry.org">http://software-carpentry.org</a>.
   </li>
 </ul>
 <p>With the understanding that:</p>

--- a/license.html
+++ b/license.html
@@ -20,7 +20,7 @@
 <p>Under the following conditions:</p>
 <ul>
   <li>
-    <strong>Attribution</strong>&mdash;You must attribute the work using "Copyright &copy; Software Carpentry" (but not in any way that suggests that we endorse you or your use of the work).  Where practical, you must also include a hyperlink to <a href="http://software-carpentry.org">http://software-carpentry.org</a>.
+    <strong>Attribution</strong>&mdash;You must attribute the work using "Copyright &copy; Software Carpentry Contributors" (but not in any way that suggests that we endorse you or your use of the work).  Where practical, you must also include a hyperlink to <a href="http://software-carpentry.org">http://software-carpentry.org</a>.
   </li>
 </ul>
 <p>With the understanding that:</p>
@@ -85,6 +85,16 @@
   "Software Carpentry&mdash;A Tool-Based Approach to Monte Carlo Radiation Transport"
   (<cite>Proc. 8th Int'l Conference on Radiation Shielding</cite>, 1994).
 -->
+
+<h2>Who are the Software Carpentry Contributors?</h2>
+
+<p>
+  Different people have contributed to Software Carpentry in different ways,
+  so the copyright owners for a given Git repository will be listed in that
+  repository's <code>AUTHORS</code> file.  In some cases (especially for
+  source code), copyright owners for a particular file will be listed in
+  a copyright comment at the beginning of the file in question.
+</p>
 
 {% endblock content %}
 


### PR DESCRIPTION
The initial version of this pull request is a work in progress.  Don't
merge yet!

Motivation: as I mentioned in #63, I've written an
`update-copyright.py` script [1](http://pypi.python.org/pypi/update-copyright/) to automatically keep track of boring
copyright/license details.  The script reads the VCS history to
generate a list of authors who have contributed to the repository (it
can also automatically update per-file copyright blurbs, but I'm not
using that here yet).  Because SWC doesn't require copyright
assignment, something along these lines (even if it's just maintaining
the `AUTHORS` file by had) is probably required, or we'll be violating
the MIT/CC BY license under which we accept patches from contributors.

Drawbacks to using my script over updating `AUTHORS` by hand:
- Another dependency!  Although if update-copyright becomes to
  burdensome it is easy to switch to manual maintenance later.  Just
  remove `.update-copyright.conf` from version control.

Benefits to using my script:
- You don't have to remember to bump the `AUTHORS` file ever again.
  Just run `update-copyright.py` before tagging a release (or once
  every few months).

Issues to be resolved:
- I don't have names for a goodly number of
  http://svn.software-carpentry.org contributors, and I don't have any
  information at all about where the pre-2009 content came from (it
  was in http://swc.scipy.org/svn/All, but then lost during the move
  to http://svn.software-carpentry.org).

This PR, if accepted, should probably be rebased on top of #177 to
avoid double-counting contributors with inconsistent Git author IDs.

```
 http://blog.tremily.us/posts/update-copyright/
```
