### PR TITLE
Updating instructions for running the Firefox SQLite Manager

### DIFF
--- a/setup/common.html
+++ b/setup/common.html
@@ -16,6 +16,6 @@
 <li>Double-click to select <strong>SQLite Manager 0.7.7</strong></li>
 <li>Click <strong>Install</strong></li>
 <li>Click <strong>restart now</strong></li>
-<li>When Firefox restarts, Select <strong>Tools</strong> =&gt; <strong>SQLite Manager</strong></li>
+<li>When Firefox restarts, Select either <strong>Web Developer</strong> =&gt; <strong>SQLite Manager</strong> or <strong>Tools</strong> =&gt; <strong>SQLite Manager</strong></li>
 </ul>
 {% endblock content %}


### PR DESCRIPTION
As described in #184 the instructions for running SQLite Manager were out of date.
