### PR TITLE
Convert `=&gt;` to the more semantic `&rarr;`.

### DIFF
--- a/setup/common.html
+++ b/setup/common.html
@@ -10,12 +10,12 @@
 <p>The SQLite Manager add-on can be installed through the "Add-ons Manager" in Firefox.</p>
 <ul>
 <li>Start Firefox</li>
-<li>Select <strong>Tools</strong> =&gt;<strong> Add-ons</strong></li>
+<li>Select <strong>Tools</strong> &rarr;<strong> Add-ons</strong></li>
 <li>In the search field, enter <code>sqlite</code></li>
 <li>Click the search icon</li>
 <li>Double-click to select <strong>SQLite Manager 0.7.7</strong></li>
 <li>Click <strong>Install</strong></li>
 <li>Click <strong>restart now</strong></li>
-<li>When Firefox restarts, Select <strong>Tools</strong> =&gt; <strong>SQLite Manager</strong></li>
+<li>When Firefox restarts, Select <strong>Tools</strong> &rarr; <strong>SQLite Manager</strong></li>
 </ul>
 {% endblock content %}

--- a/setup/index.html
+++ b/setup/index.html
@@ -262,9 +262,9 @@ $ firefox
 <h2>Firefox SQLite manager for a relational database</h2>
 <p>Once Firefox is running:</p>
 <ul>
-<li>Select <strong>Tools</strong> =&gt; <strong>SQLite Manager</strong></li>
+<li>Select <strong>Tools</strong> &rarr; <strong>SQLite Manager</strong></li>
 <li>SQLite Manager window appears</li>
-<li>Select <strong>Database</strong> =&gt; <strong>New database</strong></li>
+<li>Select <strong>Database</strong> &rarr; <strong>New database</strong></li>
 </ul>
 <p><a href="http://code.google.com/p/sqlite-manager/">http://code.google.com/p/sqlite-manager/</a></p>
 {% endblock content %}

--- a/setup/osx.html
+++ b/setup/osx.html
@@ -27,7 +27,7 @@
 <ul>
 <li>Click <strong>Applications</strong></li>
 <li>Click <strong>XCode</strong></li>
-<li>Select <strong>XCode</strong> =&gt; <strong>Preferences...</strong></li>
+<li>Select <strong>XCode</strong> &rarr; <strong>Preferences...</strong></li>
 <li>Click <strong>Downloads</strong></li>
 <li>Select <strong>Command Line Tools</strong></li>
 <li>Click <strong>Install</strong></li>

--- a/setup/terminal.html
+++ b/setup/terminal.html
@@ -8,11 +8,11 @@
 <p>To check your software or install it for a boot camp requires you to use a  terminal window (also commonly called a command-line <a href="http://en.wikipedia.org/wiki/Shell_(computing)">shell </a>or <a href="http://en.wikipedia.org/wiki/Terminal_emulator">terminal emulator</a>).</p>
 <p>Here are ways to get a terminal window for popular operating systems.</p>
 <p><strong>To get a terminal window in Ubuntu:</strong></p>
-<p>Select the menu <strong>Applications</strong> =&gt; <strong>Accessories</strong> and select <strong>Terminal.</strong> You should see a terminal window like,</p>
+<p>Select the menu <strong>Applications</strong> &rarr; <strong>Accessories</strong> and select <strong>Terminal.</strong> You should see a terminal window like,</p>
 <p><a href="{{root_path}}/files/2012/10/ubuntu-terminal.jpg"><img title="ubuntu-terminal" src="{{root_path}}/files/2012/10/ubuntu-terminal-300x197.jpg" alt="Ubuntu terminal" width="300" height="197" /></a></p>
 <p><strong>To get a terminal window in RedHat/Scientific Linux 6:</strong></p>
 <p>This depends on what windowing system you are using whether it be KDE, GNOME or X-windows.</p>
-<p>For example, for GNOME select the menu <strong>Applications</strong> =&gt; <strong>System Tools</strong> and select <strong>Terminal</strong>. You should see a terminal window like,</p>
+<p>For example, for GNOME select the menu <strong>Applications</strong> &rarr; <strong>System Tools</strong> and select <strong>Terminal</strong>. You should see a terminal window like,</p>
 <p><img src="{{root_path}}/files/2012/10/gnome-terminal-300x195.jpg" alt="Gnome terminal" /></p>
 <p><strong>To get a terminal window in Cygwin under Windows:</strong></p>
 <p>For Cygwin under Windows, start the Cygwin Terminal by clicking on your desk-top icon which looks like,</p>


### PR DESCRIPTION
`&rarr;` is defined in the HTML 4 spec [1](http://www.w3.org/TR/html4/sgml/entities.html):

  <!ENTITY rarr CDATA "&#8594;" -- rightwards arrow, U+2192 ISOnum -->

This should probably wait until after an lxml migration (see
discussion in #168) so we don't confuse Python's stdlib xml parser.
