### PR TITLE
Modified map pop-up so that location and date are links

### DIFF
--- a/bootcamps/index.html
+++ b/bootcamps/index.html
@@ -61,10 +61,8 @@
         });
 
     var info_string = '<div id="info-window">' +
-        '<h5>{{bootcamp.venue}}</h5><h6>{{bootcamp.date}}</h6>' +
-        '<p>Visit the ' +
-        '<a href="{{bootcamp.slug}}.html">' +
-        'boot camp page</a> for more info.</p>' +
+        '<h5><a href="{{bootcamp.slug}}.html">{{bootcamp.venue}}</a></h5>' +
+        '<h6><a href="{{bootcamp.slug}}.html">{{bootcamp.date}}</a></h6>' +
         '</div>';
 
     set_info_window(map, marker, info_window, info_string);


### PR DESCRIPTION
Google Map pop-ups now hyperlink the location and date, so that we don't need the 'See page' text underneath.
