### PR TITLE
Move license links

### DIFF
--- a/_base.html
+++ b/_base.html
@@ -105,6 +105,7 @@
               </a>
               <ul class="dropdown-menu" role="menu">
                 <li><a href="{{root_path}}/about/faq.html">FAQ</a></li>
+                <li><a href="{{root_path}}/license.html">License</a></li>
                 <li><a href="{{root_path}}/about/credits.html">Sponsors</a></li>
                 <li><a href="{{root_path}}/about/team.html">Team</a></li>
                 <li><a href="{{root_path}}/about/contributing.html">Contributing</a></li>
@@ -177,7 +178,6 @@
                 <li><a href="{{root_path}}/badges/organizer.html">Organizers</a></li>
               </ul>
             </li>
-            <li id="nav-license"><a href="{{root_path}}/license.html">License</a></li>
           </ul>
           <form class="navbar-search pull-right" method="get" action="http://www.google.com/search">
             <input type="hidden" name="sitesearch" value="{{site}}" />
@@ -207,21 +207,18 @@
       </div>
 
       <div class="footer">
-        <a href="{{root_path}}/license.html">
-          <img src="{{root_path}}/img/creative-commons-attribution-license.png" alt="Creative Commons Attribution License" />
+        <a class="label swc-blue-bg"
+           href="https://twitter.com/swcarpentry">Twitter</a>
+        <a class="label swc-blue-bg"
+           href="https://github.com/swcarpentry">GitHub</a>
+        <a class="label swc-blue-bg"
+           href="http://software-carpentry.org/feed.xml">RSS</a>
+        <a class="label swc-blue-bg"
+           href="{{root_path}}/license.html">License</a>
+        <a class="bugreport label swc-blue-bg"
+           href="mailto:{{contact_email}}?subject=bug%20in%20{{filename}}">
+           Bug Report
         </a>
-        <span class="pull-right">
-          <a class="label swc-blue-bg"
-             href="https://twitter.com/swcarpentry">Twitter</a>
-          <a class="label swc-blue-bg"
-             href="https://github.com/swcarpentry">GitHub</a>
-          <a class="label swc-blue-bg"
-             href="http://software-carpentry.org/feed.xml">RSS</a>
-          <a class="bugreport label swc-blue-bg"
-             href="mailto:{{contact_email}}?subject=bug%20in%20{{filename}}">
-             Bug Report
-          </a>
-        </span>
       </div>
 
     </div>

--- a/css/swc.css
+++ b/css/swc.css
@@ -120,13 +120,9 @@ div.files {
 div.footer {
     clear: both;
     background: url("/img/main_shadow.png") repeat-x scroll center top #FFFFFF;
-    padding: 10px;
+    padding: 4px 10px 7px 10px;
     border-top: 1px solid #A6A6A6;
-}
-
-/* Bug report link on footer */
-div.footer .bugreport {
-    margin-top: 4px;   /* unseemly hack to centre the text */
+    text-align: right;
 }
 
 .swc-blue-bg {

--- a/license.html
+++ b/license.html
@@ -4,7 +4,7 @@
   <meta name="title" content="License" />
 {% endblock file_metadata %}
 
-{% block navhighlight %}{{navhighlight('license')}}{% endblock navhighlight %}
+{% block navhighlight %}{{navhighlight('about')}}{% endblock navhighlight %}
 
 {% block content %}
 


### PR DESCRIPTION
I moved the "License" link from the navbar under "About", removed the CC-BY image from the lower-left, and added a "License" badge among the others in the lower-right.
