### PR TITLE
blog/2013/01/visualizing: Link to "Categorization of Used Nuclear..."

### DIFF
--- a/blog/2013/01/visualizing-nuclear-fuel-inventories.html
+++ b/blog/2013/01/visualizing-nuclear-fuel-inventories.html
@@ -12,6 +12,6 @@
 
 <img src="{{root_path}}/files/2013/01/peterson-graph.png" />
 
-<p>(Image taken from Wagner et al, "Categorization of Used Nuclear Fuel Inventory in Support of a Comprehensive National Nuclear Fuel Cycle Strategy", ORNL/TM-2012/308.)</p>
+<p>(Image taken from <a href="http://info.ornl.gov/sites/publications/files/Pub37993.pdf">Wagner et al, "Categorization of Used Nuclear Fuel Inventory in Support of a Comprehensive National Nuclear Fuel Cycle Strategy", ORNL/TM-2012/308.)</a></p>
 
 {% endblock content %} 


### PR DESCRIPTION
If we reference a paper, we might as well link to it.  Hopefully the ornl.gov
link will be pretty stable.
