### PR TITLE
Added check-bare to the Makefile for doing an unvalidated build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,14 @@ install :
 ## check        : rebuild entire site locally for checking purposes.
 check : $(STATIC_DST) $(OUT_DIR)/.htaccess
 	@make ascii-chars
-	$(COMPILE) -m blog/metadata.json -r $(BLOG_RSS_FILE) -c $(ICALENDAR_FILE) index.html
+	@make check-bare
 	@make check-links
 	@make book-figref
 	@make blog-journal
+
+## check-bare   : rebuild entire site locally, but do not validate html 
+check-bare: $(STATIC_DST) $(OUT_DIR)/.htaccess
+	$(COMPILE) -m blog/metadata.json -r $(BLOG_RSS_FILE) -c $(ICALENDAR_FILE) index.html
 
 ## blog-next-id : find the next blog entry ID to use.
 blog-next-id :


### PR DESCRIPTION
The reason I'm adding this option is because whilst adding features to the website, I often go through iterations of adding content and rebuild to check that the website looks okay. I find myself always stopping make when it gets to the validation step because early on I just don't care if it's valid or not (it probably is, and if not, I'll fix it up later once the site looks as it should). 
