### PR TITLE
Added link to VU Amsterdam bootcamp website on our bootcamp page

### DIFF
--- a/bootcamps/2013-05-vu.html
+++ b/bootcamps/2013-05-vu.html
@@ -14,4 +14,7 @@
 {% include "_requirements.html" %}
 {% include "_content.html" %}
 {% include "_contact.html" %}
+<a href="http://www.data2semantics.org/bootcamp/" class="btn btn-info">Visit Bootcamp Website &raquo;</a>
+<p class="muted">Visit this link to register for the bootcamp and find out
+additional bootcamp details.</p>
 {% endblock content %}


### PR DESCRIPTION
Looks like this: 
![image](https://f.cloud.github.com/assets/509382/121091/5a4e9856-6d6c-11e2-8757-b51c688ca62e.png)
