### PR TITLE
Blog post on expanding the types of boot-camps we do.

### DIFF
--- a/blog/2013/02/expanding-boot-camp-types.html
+++ b/blog/2013/02/expanding-boot-camp-types.html
@@ -1,0 +1,41 @@
+{% extends "_blog.html" %}
+{% block file_metadata %}
+<meta name="post_id" content="5405" />
+<meta name="author_id" content="davis.m" />
+<meta name="title" content="Expanding Our Boot Camp Types" />
+<meta name="post_date" content="2013-02-15" />
+<meta name="category" content="boot-camp" />
+<meta name="category" content="versions-5-0" />
+{% endblock file_metadata %}
+{% block content %}
+
+<p>Prompted by a recent email I gave some thought to our plans to expand the
+types of boot camps we offer, especially when it comes to a sort of &ldquo;next
+level&rdquo; boot camp and whether we might offer boot camps that introduce
+traditional software developers to the world of scientific programming:</p>
+
+<p>There is significant discussion on the best way to expand Software
+Carpentry. Longer boot camps, advanced boot camps, etc. At some point we need
+to start actually experimenting with these things, but we have many
+constraints, most notably a severe shortage of person-hours to devote to
+developing curriculum and staffing events. Scientists, it turns out, are very
+busy people!</p>
+
+<p>We focus on teaching software engineering to scientists, but I think it
+would be an interesting experiment to try to identify the overlapping interests
+of Software Carpentry graduates and web developers and run a boot camp based on
+that. I could see people getting a lot out of the co-mingling at such an
+event.</p>
+
+<p>Picking curriculum could be a challenge. Do we keep it general or pick a
+subfield? Even in our regular boot camps we find it useful to change lessons
+based on the audience. Biologists are into SQL, physicists more interested in
+fast numeric processing. And the more specific we make things the fewer people
+we interest. My mind goes immediately to scientific Python but then that&#39;s
+my specialty.</p>
+
+<p>If you have thoughts on what to teach in a &ldquo;next level&rdquo; boot
+camp please leave them in the comments, and if you&#39;d like to host one
+please <a href="mailto:info@software-carpentry.org">get in touch</a>!</p>
+
+{% endblock content %}


### PR DESCRIPTION
Text of post:

---

<p>Prompted by a recent email I gave some thought to our plans to expand the types
of boot camps we offer, especially when it comes to a sort of &ldquo;next level&rdquo; boot
camp and whether we might offer boot camps that introduce traditional software
developers to the world of scientific programming:</p>


<p>There is significant discussion on the best way to expand Software Carpentry.
Longer boot camps, advanced boot camps, etc. At some point we need to
start actually experimenting with these things, but we have many constraints,
most notably a severe shortage of person-hours to devote to developing
curriculum and staffing events. Scientists, it turns out, are very busy people!</p>


<p>We focus on teaching software engineering to scientists, but I think it would
be an interesting experiment to try to identify the overlapping interests of
Software Carpentry graduates and web developers and run a boot camp based on
that. I could see people getting a lot out of the co-mingling at such an event.</p>


<p>Picking curriculum could be a challenge. Do we keep it general or pick a
subfield? Even in our regular boot camps we find it useful to change lessons
based on the audience. Biologists are into SQL, physicists more interested in
fast numeric processing. And the more specific we make things the fewer people
we interest. My mind goes immediately to scientific Python but then that&#39;s my
specialty.</p>


<p>If you have thoughts on what to teach in a &ldquo;next level&rdquo; boot camp please leave
them in the comments, and if you&#39;d like to host one please
<a href="mailto:info@software-carpentry.org">get in touch</a>!</p>
