### PR TITLE
Added pages for upcoming UK boot camps

### DIFF
--- a/bootcamps/2013-04-egi-forum.html
+++ b/bootcamps/2013-04-egi-forum.html
@@ -1,0 +1,38 @@
+{% extends "_bootcamp.html" %}
+{% block file_metadata %}
+  <meta name="venue" content="EGI Forum, Manchester" />
+  <meta name="date" content="April 2013" />
+  <meta name="startdate" content="2013-04-11" />
+  <meta name="latlng" content="53.467102, -2.233958" />
+{% endblock file_metadata %}
+{% block content %}
+<p><strong>Where:</strong> EGI Forum, Manchester.</p>
+<p><strong>When:</strong> April 11th, 2013 between 10:00 and 17:30</p>
+<p>
+  <strong>What:</strong>
+  Our goal is to help scientists and engineers become more productive
+  by teaching them basic computing skills. At the EGI Forum we will be
+  hosting a day of boot camp "highlights". This consists of 3 standalone
+  sessions which provide a short introduction to 3 valuable computing
+  skills and that will also give attendees a flavour of what a full 
+  boot camp is like.
+</p>
+{% include "_who.html" %}
+<p>
+  <strong>Requirements:</strong>
+Participants can bring their own laptop with specific software packages installed. Alternatively they can download and run a VMWare Virtual machine. If this is not possible, then accounts will be made available on the day.
+</p>
+<p>
+  <strong>Content:</strong> The syllabus for this boot camp will include:
+</p>
+<ul>
+<li>Using version control to manage and share information</li>
+<li>How (and how much) to test programs</li>
+<li>Approaches to data management</li>
+</ul>
+{% include "_contact.html" %}
+<p>
+  <strong>Registration</strong>:
+  The boot camp highlights sessions are open to anyone attending the <a href="http://cf2013.egi.eu/">EGI Forum</a>.
+</p>
+{% endblock content %}

--- a/bootcamps/2013-05-oxford-dtc.html
+++ b/bootcamps/2013-05-oxford-dtc.html
@@ -1,0 +1,22 @@
+{% extends "_bootcamp.html" %}
+{% block file_metadata %}
+  <meta name="venue" content="University of Oxford" />
+  <meta name="date" content="May 2013" />
+  <meta name="startdate" content="2013-05-09" />
+  <meta name="enddate" content="2013-05-10" />
+  <meta name="latlng" content="51.759865,-1.258648" />
+{% endblock file_metadata %}
+{% block content %}
+<p><strong>Where:</strong> University of Oxford.</p>
+<p><strong>When:</strong> May 9-10, 2013. We will start at 9:00 and end at 4:30 each day.</p>
+{% include "_what.html" %}
+{% include "_who.html" %}
+{% include "_requirements.html" %}
+{% include "_content.html" %}
+{% include "_contact.html" %}
+<p>
+  <strong>Registration</strong>:
+  This boot camp is for the Doctoral Training Centres at The University of Oxford.
+</p>
+
+{% endblock content %}

--- a/bootcamps/2013-06-soton.html
+++ b/bootcamps/2013-06-soton.html
@@ -1,0 +1,21 @@
+{% extends "_bootcamp.html" %}
+{% block file_metadata %}
+  <meta name="venue" content="University of Southampton" />
+  <meta name="date" content="June 2013" />
+  <meta name="startdate" content="2013-06-01" />
+  <meta name="enddate" content="2013-06-30" />
+  <meta name="latlng" content="50.937608,-1.395671" />
+{% endblock file_metadata %}
+{% block content %}
+<p><strong>Where:</strong> University of Southampton.</p>
+<p><strong>When:</strong> June, 2013 (exact days to be determined). We will start at 9:00 and end at 4:30 each day.</p>
+{% include "_what.html" %}
+{% include "_who.html" %}
+{% include "_requirements.html" %}
+{% include "_content.html" %}
+{% include "_contact.html" %}
+<p>
+  <strong>Registration</strong>:
+  This boot camp is for members of the Institute for Complex Systems Simulation, The University of Southampton.
+</p>
+{% endblock content %}

--- a/bootcamps/2013-11-exeter.html
+++ b/bootcamps/2013-11-exeter.html
@@ -1,0 +1,21 @@
+{% extends "_bootcamp.html" %}
+{% block file_metadata %}
+  <meta name="venue" content="University of Exeter" />
+  <meta name="date" content="June 2013" />
+  <meta name="startdate" content="2013-11-01" />
+  <meta name="enddate" content="2013-11-30" />
+  <meta name="latlng" content="50.735980,-3.534272" />
+{% endblock file_metadata %}
+{% block content %}
+<p><strong>Where:</strong> University of Exeter.</p>
+<p><strong>When:</strong>  November, 2013 (exact days to be determined). We will start at 9:00 and end at 4:30 each day.</p>
+{% include "_what.html" %}
+{% include "_who.html" %}
+{% include "_requirements.html" %}
+{% include "_content.html" %}
+{% include "_contact.html" %}
+<p>
+  <strong>Registration</strong>:
+  This boot camp is for physicists, engineers, biologists associated with the Wellcome Trust Biomedical Informatics Hub, The University of Exeter.
+</p>
+{% endblock content %}

--- a/bootcamps/2013-11-tremough.html
+++ b/bootcamps/2013-11-tremough.html
@@ -1,0 +1,21 @@
+{% extends "_bootcamp.html" %}
+{% block file_metadata %}
+  <meta name="venue" content="University of Exeter, Tremough campus" />
+  <meta name="date" content="June 2013" />
+  <meta name="startdate" content="2013-11-01" />
+  <meta name="enddate" content="2013-11-30" />
+  <meta name="latlng" content="50.171071,-5.125101" />
+{% endblock file_metadata %}
+{% block content %}
+<p><strong>Where:</strong> University of Exeter, Tremough campus.</p>
+<p><strong>When:</strong>  November, 2013 (exact days to be determined). We will start at 9:00 and end at 4:30 each day.</p>
+{% include "_what.html" %}
+{% include "_who.html" %}
+{% include "_requirements.html" %}
+{% include "_content.html" %}
+{% include "_contact.html" %}
+<p>
+  <strong>Registration</strong>:
+  This boot camp is for physicists, engineers, biologists associated with the Wellcome Trust Biomedical Informatics Hub, The University of Exeter.
+</p>
+{% endblock content %}


### PR DESCRIPTION
EGI Forum, Manchester 11 April (boot camp "highlights" day)
Oxford DTCs, Oxford, 19-20 May
ICSS, Southampton, June (dates to be decided)
Wellcome Trust, University of Exeter, November (dates to be decided depending on interest)
Wellcome Trust, University of Exeter (Tremough Campus), November (dates to be decided depending on interest)
