### PR TITLE
Removed registration form on Arizona camp page (temporary, until registration opens).

### DIFF
--- a/bootcamps/2013-04-arizona.html
+++ b/bootcamps/2013-04-arizona.html
@@ -15,5 +15,7 @@
 {% include "_requirements.html" %}
 {% include "_content.html" %}
 {% include "_contact.html" %}
-{{eventbrite(page.eventbrite_key, page.venue, page.date)}}
+<p>
+Registration will begin soon.
+</p>
 {% endblock content %}


### PR DESCRIPTION
I removed the EventBrite registration form and replaced it with a "Registration will open soon" message.
