### PR TITLE
Menu bar on web site fails on Internet Explorer

### DIFF
--- a/blog/_blog.html
+++ b/blog/_blog.html
@@ -1,5 +1,5 @@
-<!-- pageclass: BlogPostPage -->
 {% extends "_base.html" %}
+<!-- pageclass: BlogPostPage -->
 
 {% block pagetitle %}<title>Software Carpentry: {{page.title}}</title>{% endblock pagetitle %}
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,5 +1,5 @@
-<!-- pageclass: BlogIndexPage -->
 {% extends "_base.html" %}
+<!-- pageclass: BlogIndexPage -->
 
 {% block file_metadata %}
   <meta name="title" content="Blog" />

--- a/bootcamps/_bootcamp.html
+++ b/bootcamps/_bootcamp.html
@@ -1,5 +1,5 @@
-<!-- pageclass: BootCampPage -->
 {% extends "_base.html" %}
+<!-- pageclass: BootCampPage -->
 
 {% macro eventbrite(key, venue, date) -%}
   {% if key %}


### PR DESCRIPTION
A user reports:

I was checking out the lessons, and when you do the top menu bar stops functioning completely. You cannot select anything to see sub folders and whatnot. I have attached a screenshot.
I am using the latest version of internet explorer to view the site.

See @gvwilson for user's contact info.

![site bug](https://f.cloud.github.com/assets/911566/146204/da13f520-7480-11e2-8617-7fed631bc974.png)
