### PR TITLE
Adding a Staffing page showing who's teaching where

### DIFF
--- a/_base.html
+++ b/_base.html
@@ -159,6 +159,7 @@
                 <li><a href="{{root_path}}/bootcamps/index.html#past">Past Boot Camps</a></li>
                 <li><a href="{{root_path}}/bootcamps/conduct.html">Code of Conduct</a></li>
                 <li><a href="{{root_path}}/bootcamps/how-to.html">How To Run a Boot Camp</a></li>
+                <li><a href="{{root_path}}/bootcamps/staffing.html">Staffing</a></li>
               </ul>
             </li>
             <li id="nav-blog" class="dropdown">

--- a/bootcamps/index.html
+++ b/bootcamps/index.html
@@ -154,9 +154,9 @@
   <p>Want to know more?  See our <a href="{{root_path}}/about/faq.html">FAQ</a>.  Want to
   organize one?  See our <a href="how-to.html">how-to</a> guide.</p>
 
-  <p>And please note: all boot camp participants are expected to abide
+  <p><em>All boot camp participants are expected to abide
   by our <a href="conduct.html">code of conduct</a> to ensure that all
-  attendees to have an enjoyable and fulfilling experience.</p>
+  attendees to have an enjoyable and fulfilling experience.</em></p>
 </section>
 
 <h2 id="future">Future Boot Camps</h2>
@@ -167,13 +167,14 @@
     <tr>
       <td class="link"><a href="{{bootcamp.slug}}.html">{{bootcamp.venue}}</a></td>
       <td class="registration">
-      {% if bootcamp.registration %}{{bootcamp.registration}}{% endif %}
+        {% if bootcamp.registration %}{{bootcamp.registration}}{% endif %}
       </td>
       <td class="date">{{bootcamp.date}}</td>
     </tr>
   {% endif %}
 {% endfor %}
 </table>
+<p>See also our list of <a href="staffing.html">who's teaching where</a>.</p>
 
 <div id="map_canvas" style="width: 98%; height: 500px; margin-left:auto; margin-right: auto;"></div>
 <div style="margin-bottom: 20px;">

--- a/bootcamps/staffing.html
+++ b/bootcamps/staffing.html
@@ -1,0 +1,127 @@
+{% extends "_base.html" %}
+{% block file_metadata %}
+  <meta name="title" content="Boot Camp Staffing" />
+{% endblock file_metadata %}
+{% block content %}
+<h3>Last Updated 2013-03-03</h3>
+<table cellpadding="5">
+<tr><td align="center" colspan="4"><strong>Upcoming Boot Camps</strong></td></tr>
+<tr><td valign="top"><strong>Bootcamp ID</strong></td><td valign="top"><strong>Start Date</strong></td><td valign="top"><strong>Venue</strong></td><td valign="top"><strong>People</strong></td></tr>
+<tr><td valign="top">2013-03-lbl-a</td><td valign="top">2013-03-04</td><td valign="top">Lawrence Berkeley National Laboratory</td><td valign="top">Chris Holdgraf (helper)<br/>Geoff Oxberry (instructor)<br/>Matt Terry (helper)<br/>Greg Wilson (instructor)</td></tr>
+<tr><td valign="top">2013-03-lbl-b</td><td valign="top">2013-03-06</td><td valign="top">Lawrence Berkeley National Laboratory</td><td valign="top">Matthew Brett (helper)<br/>Shreyas Cholia (instructor)<br/>Paul Ivanov (helper)<br/>Justin Kitzes (instructor)<br/>Cindee Madison (helper)<br/>Ariel Rokem (helper)<br/>Matt Terry (helper)</td></tr>
+<tr><td valign="top">2013-03-virginia</td><td valign="top">2013-03-07</td><td valign="top">University of Virginia</td><td valign="top">Carlos Anderson (instructor)<br/>Stephen Crouch (instructor)<br/>Ben Morris (instructor)<br/>Stephen Turner (host)</td></tr>
+<tr><td valign="top">2013-03-aub</td><td valign="top">2013-03-20</td><td valign="top">American University in Beirut</td><td valign="top">Aron Ahmadia (instructor)<br/>Andy Terrel (instructor)<br/>George Turkiyyah (host)</td></tr>
+<tr><td valign="top">2013-03-utahstate</td><td valign="top">2013-03-23</td><td valign="top">Utah State University</td><td valign="top">Dan McGlinn (instructor)<br/>Ethan White (instructor)</td></tr>
+<tr><td valign="top">2013-04-arizona</td><td valign="top">2013-04-04</td><td valign="top">University of Arizona</td><td valign="top">C. Titus Brown (instructor)<br/>Karen Cranston (instructor)<br/>Katie Cunningham (helper)<br/>Richard Enbody (instructor)<br/>Brian Enquist (host)<br/>David Koop (instructor)<br/>Chas Leichner (helper)<br/>Julie Messier (host)<br/>Pascal Mickelson (helper)</td></tr>
+<tr><td valign="top">2013-04-egi-forum</td><td valign="top">2013-04-13</td><td valign="top">European Grid Infrastructure</td><td valign="top">Michel Drescher (host)<br/>Mike Jackson (instructor)<br/>Richard McLennan (host)</td></tr>
+<tr><td valign="top">2013-04-manchester</td><td valign="top">2013-04-18</td><td valign="top">University of Manchester</td><td valign="top">Casey Bergman (host)<br/>Peter Briggs (helper)<br/>Tim Burgis (helper)<br/>Michael Croucher (helper)<br/>Carole Goble (host)<br/>Safe Hammad (helper)<br/>Dave Hughes (helper)<br/>Mike Jackson (instructor)<br/>David Jones (instructor)<br/>Thomas Kluyver (helper)<br/>Aleksandra Pawlik (instructor)<br/>Barry Rowlingson (helper)<br/>Shoaib Sufi (helper)<br/>Katy Wolstencroft (helper)</td></tr>
+<tr><td valign="top">2013-04-paris</td><td valign="top">2013-04-20</td><td valign="top">Telecom ParisTech</td><td valign="top">Sergi Blanco Cuaresma (instructor)<br/>Christophe Cossou (instructor)<br/>Alexandre Gramfort (instructor)<br/>Konrad Hinsen (instructor)<br/>Nicolas Limare (instructor)<br/>Gael Varoquaux (instructor)<br/>Nelle Varoquaux (instructor)</td></tr>
+<tr><td valign="top">2013-04-wisc</td><td valign="top">2013-04-29</td><td valign="top">University of Wisconsin - Madison</td><td valign="top">Katy Huff (instructor)<br/>Steve McGough (instructor)<br/>Paul Wilson (host)</td></tr>
+<tr><td valign="top">2013-05-vu</td><td valign="top">2013-05-02</td><td valign="top">Vrije Universiteit</td><td valign="top">Onno Broekmans (host)<br/>Stefano Cozzini (instructor)<br/>Justin Ely (instructor)<br/>Paul Groth (host)</td></tr>
+<tr><td valign="top">2013-05-geomar</td><td valign="top">2013-05-06</td><td valign="top">GEOMAR (Kiel)</td><td valign="top">Avan Antia (host)<br/>Stefano Cozzini (instructor)<br/>Justin Ely (helper)<br/>Angelika Hoffmann (helper)<br/>Rainer Kiko (helper)<br/>Christiane Schelten (helper)</td></tr>
+<tr><td valign="top">2013-05-hhmi</td><td valign="top">2013-05-06</td><td valign="top">Howard Hughes Medical Institute</td><td valign="top">Adina Chuang Howe (instructor)<br/>Michael Hansen (instructor)<br/>Gabe Murphy (host)</td></tr>
+<tr><td valign="top">2013-05-stanford</td><td valign="top">2013-05-06</td><td valign="top">Stanford</td><td valign="top">Miriam Goodman (host)<br/>Paul Ivanov (instructor)<br/>Bernhard Konrad (instructor)<br/>Ariel Rokem (instructor)</td></tr>
+<tr><td valign="top">2013-05-lbl</td><td valign="top">2013-05-09</td><td valign="top">Lawrence Berkeley National Laboratory</td><td valign="top">Matt Davis (instructor)<br/>Tracy Teal (instructor)</td></tr>
+<tr><td valign="top">2013-05-oxford-dtc</td><td valign="top">2013-05-09</td><td valign="top">University of Oxford</td><td valign="top">Mario Antonioletti (instructor)<br/>Jonathan Cooper (host)<br/>Shoaib Sufi (instructor)</td></tr>
+<tr><td valign="top">2013-05-ucb</td><td valign="top">2013-05-09</td><td valign="top">University of California Berkeley</td><td valign="top">Justin Kitzes (instructor)<br/>Karthik Ram (instructor)</td></tr>
+<tr><td valign="top">2013-05-ucdavis</td><td valign="top">2013-05-13</td><td valign="top">University of California Davis</td><td valign="top">Azalee Bostroem (instructor)<br/>Vince Buffalo (helper)<br/>Matt Davis (instructor)<br/>Chloe Lewis (helper)<br/>Tracy Teal (instructor)</td></tr>
+<tr><td valign="top">2013-05-umass</td><td valign="top">2013-05-23</td><td valign="top">University of Massachusetts</td><td valign="top">Kristen De Angelis (host)<br/>Tracy Teal (instructor)</td></tr>
+<tr><td valign="top">2013-05-alberta</td><td valign="top">2013-05-30</td><td valign="top">University of Alberta</td><td valign="top">Paul Lu (host)<br/>Charlene Nielsen (instructor)<br/>Greg Wilson (instructor)</td></tr>
+<tr><td valign="top">2013-07-oslo</td><td valign="top">2013-07-03</td><td valign="top">University of Oslo</td><td valign="top">Dave Clements (host)<br/>Karin Lagesen (instructor)<br/>Lex Nederbragt (instructor)</td></tr>
+<tr><td valign="top">2013-07-bath</td><td valign="top">2013-07-15</td><td valign="top">University of Bath</td><td valign="top">Alex Chartier (host)<br/>Mike Jackson (instructor)</td></tr>
+</table>
+<table cellpadding="5">
+<tr><td align="center" colspan="2"><strong>Staffing</strong></td></tr>
+<tr><td valign="top"><strong>Person</strong></td><td valign="top"><strong>Venue</strong></td></tr>
+<tr><td valign="top">Aron Ahmadia</td><td valign="top">American University in Beirut</td></tr>
+<tr><td valign="top">Carlos Anderson</td><td valign="top">University of Virginia</td></tr>
+<tr><td valign="top">Avan Antia</td><td valign="top">GEOMAR (Kiel)</td></tr>
+<tr><td valign="top">Mario Antonioletti</td><td valign="top">University of Oxford</td></tr>
+<tr><td valign="top">Casey Bergman</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Sergi Blanco Cuaresma</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Azalee Bostroem</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Matthew Brett</td><td valign="top">Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">Peter Briggs</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Onno Broekmans</td><td valign="top">Vrije Universiteit</td></tr>
+<tr><td valign="top">C. Titus Brown</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Vince Buffalo</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Tim Burgis</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Alex Chartier</td><td valign="top">University of Bath</td></tr>
+<tr><td valign="top">Shreyas Cholia</td><td valign="top">Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">Adina Chuang Howe</td><td valign="top">Howard Hughes Medical Institute</td></tr>
+<tr><td valign="top">Dave Clements</td><td valign="top">University of Oslo</td></tr>
+<tr><td valign="top">Jonathan Cooper</td><td valign="top">University of Oxford</td></tr>
+<tr><td valign="top">Christophe Cossou</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Stefano Cozzini</td><td valign="top">GEOMAR (Kiel), Vrije Universiteit</td></tr>
+<tr><td valign="top">Karen Cranston</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Stephen Crouch</td><td valign="top">University of Virginia</td></tr>
+<tr><td valign="top">Michael Croucher</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Katie Cunningham</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Matt Davis</td><td valign="top">Lawrence Berkeley National Laboratory, University of California Davis</td></tr>
+<tr><td valign="top">Kristen De Angelis</td><td valign="top">University of Massachusetts</td></tr>
+<tr><td valign="top">Michel Drescher</td><td valign="top">European Grid Infrastructure</td></tr>
+<tr><td valign="top">Jonathan Eisen</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Justin Ely</td><td valign="top">GEOMAR (Kiel), Vrije Universiteit</td></tr>
+<tr><td valign="top">Richard Enbody</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Brian Enquist</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Terry Gaasterland</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Carole Goble</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Miriam Goodman</td><td valign="top">Stanford</td></tr>
+<tr><td valign="top">Alexandre Gramfort</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Paul Groth</td><td valign="top">Vrije Universiteit</td></tr>
+<tr><td valign="top">Safe Hammad</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Michael Hansen</td><td valign="top">Howard Hughes Medical Institute</td></tr>
+<tr><td valign="top">Konrad Hinsen</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Angelika Hoffmann</td><td valign="top">GEOMAR (Kiel)</td></tr>
+<tr><td valign="top">Chris Holdgraf</td><td valign="top">Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">Katy Huff</td><td valign="top">University of Wisconsin - Madison</td></tr>
+<tr><td valign="top">Dave Hughes</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Paul Ivanov</td><td valign="top">Lawrence Berkeley National Laboratory, Stanford</td></tr>
+<tr><td valign="top">Mike Jackson</td><td valign="top">European Grid Infrastructure, University of Manchester, University of Bath</td></tr>
+<tr><td valign="top">David Jones</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Guillaume Jospin</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Rainer Kiko</td><td valign="top">GEOMAR (Kiel)</td></tr>
+<tr><td valign="top">Justin Kitzes</td><td valign="top">Lawrence Berkeley National Laboratory, University of California Berkeley</td></tr>
+<tr><td valign="top">Thomas Kluyver</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Bernhard Konrad</td><td valign="top">Stanford</td></tr>
+<tr><td valign="top">David Koop</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Karin Lagesen</td><td valign="top">University of Oslo</td></tr>
+<tr><td valign="top">Jenna Morgan Lang</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Chas Leichner</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Chloe Lewis</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Nicolas Limare</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Dawei Lin</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Paul Lu</td><td valign="top">University of Alberta</td></tr>
+<tr><td valign="top">Cindee Madison</td><td valign="top">Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">Dan McGlinn</td><td valign="top">Utah State University</td></tr>
+<tr><td valign="top">Steve McGough</td><td valign="top">University of Wisconsin - Madison</td></tr>
+<tr><td valign="top">Richard McLennan</td><td valign="top">European Grid Infrastructure</td></tr>
+<tr><td valign="top">Nirav Merchant</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Julie Messier</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Pascal Mickelson</td><td valign="top">University of Arizona</td></tr>
+<tr><td valign="top">Ben Morris</td><td valign="top">University of Virginia</td></tr>
+<tr><td valign="top">James Morrison</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Gabe Murphy</td><td valign="top">Howard Hughes Medical Institute</td></tr>
+<tr><td valign="top">Russell Neches</td><td valign="top">University of California Davis</td></tr>
+<tr><td valign="top">Lex Nederbragt</td><td valign="top">University of Oslo</td></tr>
+<tr><td valign="top">Charlene Nielsen</td><td valign="top">University of Alberta</td></tr>
+<tr><td valign="top">Geoff Oxberry</td><td valign="top">Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">Aleksandra Pawlik</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Karthik Ram</td><td valign="top">University of California Berkeley</td></tr>
+<tr><td valign="top">Ariel Rokem</td><td valign="top">Lawrence Berkeley National Laboratory, Stanford</td></tr>
+<tr><td valign="top">Barry Rowlingson</td><td valign="top">University of Manchester</td></tr>
+<tr><td valign="top">Christiane Schelten</td><td valign="top">GEOMAR (Kiel)</td></tr>
+<tr><td valign="top">Shoaib Sufi</td><td valign="top">University of Manchester, University of Oxford</td></tr>
+<tr><td valign="top">Tracy Teal</td><td valign="top">Lawrence Berkeley National Laboratory, University of California Davis, University of Massachusetts</td></tr>
+<tr><td valign="top">Andy Terrel</td><td valign="top">American University in Beirut</td></tr>
+<tr><td valign="top">Matt Terry</td><td valign="top">Lawrence Berkeley National Laboratory, Lawrence Berkeley National Laboratory</td></tr>
+<tr><td valign="top">George Turkiyyah</td><td valign="top">American University in Beirut</td></tr>
+<tr><td valign="top">Stephen Turner</td><td valign="top">University of Virginia</td></tr>
+<tr><td valign="top">Gael Varoquaux</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Nelle Varoquaux</td><td valign="top">Telecom ParisTech</td></tr>
+<tr><td valign="top">Ethan White</td><td valign="top">Utah State University</td></tr>
+<tr><td valign="top">Greg Wilson</td><td valign="top">Lawrence Berkeley National Laboratory, University of Alberta</td></tr>
+<tr><td valign="top">Paul Wilson</td><td valign="top">University of Wisconsin - Madison</td></tr>
+<tr><td valign="top">Katy Wolstencroft</td><td valign="top">University of Manchester</td></tr>
+</table>
+{% endblock content %}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="subfile" content="bootcamps/conduct.html" />
   <meta name="subfile" content="bootcamps/how-to.html" />
   <meta name="subfile" content="bootcamps/office-hours.html" />
+  <meta name="subfile" content="bootcamps/staffing.html" />
   <meta name="subfile" content="setup/index.html" />
   <meta name="subfile" content="blog/index.html" />
   <meta name="subfile" content="book/index.html" />


### PR DESCRIPTION
The staffing is generated by hand from another (private) repo and will have
to be updated manually from time to time by someone with access to that repo.
This commit also includes a couple minor style changes in bootcamps/index.html.

This supersedes #336.
