### PR TITLE
Replacing 'workshop' with 'boot camp' in several places.

### DIFF
--- a/about/90seconds.html
+++ b/about/90seconds.html
@@ -39,7 +39,7 @@
   </div>
 </div>
 
-<p>We're funded by the Sloan Foundation and Mozilla, and our instructors are volunteers, so the only cost to host sites is their travel and accommodation. (We can handle registration online, or leave it in hosts' hands.) We aim for 40 people per workshop, and look for 2-3 local helpers to assist during practicals.</p>
+<p>We're funded by the Sloan Foundation and Mozilla, and our instructors are volunteers, so the only cost to host sites is their travel and accommodation. (We can handle registration online, or leave it in hosts' hands.) We aim for 40 people per boot camp, and look for 2-3 local helpers to assist during practicals.</p>
 
 <p>Two independent assessments in the spring of 2012 confirmed that what we're doing accelerates participants' research, so if there's an upcoming meeting, conference, or get-together where a lot of your intended users will be together, please <a href="mailto:{{contact_email}}">get in touch</a>: we'd welcome a chance to chat about how we could help you.</p>
 

--- a/about/faq.html
+++ b/about/faq.html
@@ -143,7 +143,7 @@ want. If you want to know more about what is involved in running a
 boot camp, please see our guide on
 <a href="{{root_path}}/bootcamps/how-to.html">how to run a boot camp</a>.</p>
 
-<p>We support groups who want to organise a workshop for their
+<p>We support groups who want to organise a boot camp for their
 institution or research community. We look for people who can act as
 a <em>local organiser</em> who will handle the logistics of selecting
 a suitable date, finding and booking a venue and catering, local

--- a/about/team.html
+++ b/about/team.html
@@ -176,7 +176,7 @@
 
 <div class="media">
   <img class="media-object pull-left" src="{{root_path}}/img/people/lasher-chris.png" alt="Chris Lasher" />
-  <div id="lasher.c" class="media-body"><span class="person">Chris Lasher</span> works at the interfaces of molecular biology, computer science, and software development. In 2007, he lead a weekly Software Carpentry workshop at Virginia Tech for postdocs and graduate students. To this day, Chris continues to improve his good programming habits and extol the virtues of Python, his most beloved programming language.</div>
+  <div id="lasher.c" class="media-body"><span class="person">Chris Lasher</span> works at the interfaces of molecular biology, computer science, and software development. In 2007, he lead a weekly Software Carpentry boot camp at Virginia Tech for postdocs and graduate students. To this day, Chris continues to improve his good programming habits and extol the virtues of Python, his most beloved programming language.</div>
 </div>
 
 <div class="media">

--- a/about/testimonials.html
+++ b/about/testimonials.html
@@ -13,7 +13,7 @@
 </blockquote>
 
 <blockquote class="testimonial">
-<p>My labmates and I attended a Software Carpentry workshop a few months ago, and since then, several graduate students and RAs have been much more willing to tackle simple programming tasks independently. We have also now implemented a version control repository in the lab: it has greatly reduced the number of files flying around and helped to ensure that everyone in the lab has the most up-to-date versions of all the code we routinely use. Its history mechanism also keeps us from having to manually document every change made or analysis done, which has greatly improved our ability to find information quickly.</p>
+<p>My labmates and I attended a Software Carpentry boot camp a few months ago, and since then, several graduate students and RAs have been much more willing to tackle simple programming tasks independently. We have also now implemented a version control repository in the lab: it has greatly reduced the number of files flying around and helped to ensure that everyone in the lab has the most up-to-date versions of all the code we routinely use. Its history mechanism also keeps us from having to manually document every change made or analysis done, which has greatly improved our ability to find information quickly.</p>
 <cite>&mdash; Lynne Williams studies the cognitive neuroscience of language development over the lifespan and develops statistical techniques to analyze large multivariate data sets.</cite>
 </blockquote>
 
@@ -58,7 +58,7 @@
 </blockquote>
 
 <blockquote class="testimonial">
-<p>Before I attended the Software Carpentry workshop, I honestly didn't think I'd pick up anything useful other than a few minor tips and tricks because I had been programming for over 6 years at that point. Much to my surprise, Software Carpentry transformed the way I approach programming. I learned how to write better, flexible software with command-line options; the importance of open-source, reusable software in research; and was introduced to the best research notebook I've encountered so far: IPython Notebook. I couldn't recommend Software Carpentry enough, even for the veteran programmers out there.</p>
+<p>Before I attended the Software Carpentry boot camp, I honestly didn't think I'd pick up anything useful other than a few minor tips and tricks because I had been programming for over 6 years at that point. Much to my surprise, Software Carpentry transformed the way I approach programming. I learned how to write better, flexible software with command-line options; the importance of open-source, reusable software in research; and was introduced to the best research notebook I've encountered so far: IPython Notebook. I couldn't recommend Software Carpentry enough, even for the veteran programmers out there.</p>
 <cite>&mdash; Randal S. Olson studies biologically-inspired artificial brains and algorithms at Michigan State University</cite>
 </blockquote>
 

--- a/book/teach.html
+++ b/book/teach.html
@@ -366,7 +366,7 @@ $ <span class="in">head -10 | wc data.txt</span>
       <p>
         It's also why installing and configuring software is
         a much bigger problem for us than experienced programmers like to acknowledge.
-        It isn't just the time we lose at the start of workshops
+        It isn't just the time we lose at the start of boot camps
         as we try to get a Unix shell working on Windows,
         or set up a version control client on some idiosyncratic Linux distribution.
         It isn't even the unfairness of asking students to debug things
@@ -494,7 +494,7 @@ $ <span class="in">head -10 | wc data.txt</span>
 
       <p>
         Second,
-        we have found that learners get more out of workshops
+        we have found that learners get more out of boot camps
         if they attend in groups,
         e.g.,
         they sign up in team of four or more,
@@ -663,7 +663,7 @@ def word_lengths(words):
 
       <p>
         As of the time of writing,
-        we haven't used this exact kind of peer instruction systematically in our workshops.
+        we haven't used this exact kind of peer instruction systematically in our boot camps.
         What we've done instead is require learners to do exercises in pairs,
         i.e.,
         have two (or three) people share a laptop

--- a/bootcamps/2011-11-toronto.html
+++ b/bootcamps/2011-11-toronto.html
@@ -7,7 +7,7 @@
   <meta name="latlng" content="43.661476,-79.395189" />
 {% endblock file_metadata %}
 {% block content %}
-<p>Software Carpentry is teaming up with <a title="Scinet" href="http://www.scinethpc.ca/about-scinet/" target="_blank">Scinet</a> and <a title="The Hacker Within" href="http://hackerwithin.org/thw/">The Hacker Within</a> to host a 2 day workshop on software engineering at the University of Toronto for graduate students in the sciences. The workshop is sold out, but we'll be posting all of our course materials here for anyone who wants to use them.</p>
+<p>Software Carpentry is teaming up with <a title="Scinet" href="http://www.scinethpc.ca/about-scinet/" target="_blank">Scinet</a> and <a title="The Hacker Within" href="http://hackerwithin.org/thw/">The Hacker Within</a> to host a 2 day boot camp on software engineering at the University of Toronto for graduate students in the sciences. The boot camp is sold out, but we'll be posting all of our course materials here for anyone who wants to use them.</p>
 <p><strong>Information for Attendees</strong></p>
 <p>Please follow the instructions on the setup page <em>before</em> November 7 so we can get a quick start.</p>
 <p>The SWC Bootcamp will be covering several topics including data storage, the shell, and a lot of Python. Everything is interactive, which means you should bring a laptop and your power cord with you both days.</p>

--- a/bootcamps/2012-01-stsci.html
+++ b/bootcamps/2012-01-stsci.html
@@ -7,14 +7,14 @@
   <meta name="latlng" content="39.332604,-76.62319" />
 {% endblock file_metadata %}
 {% block content %}
-<p>The main aim of this two-day workshop is to make sure everyone has the skills needed to tackle the material we'll be covering online over the next 5-6 weeks. Based on your responses to our survey, our schedule will be:</p>
+<p>The main aim of this two-day boot camp is to make sure everyone has the skills needed to tackle the material we'll be covering online over the next 5-6 weeks. Based on your responses to our survey, our schedule will be:</p>
 <ol>
-<li>A quick refresher on Python using invasion percolation as an example. This will also give us a running example to use in the second and third parts of the workshop.</li>
+<li>A quick refresher on Python using invasion percolation as an example. This will also give us a running example to use in the second and third parts of the boot camp.</li>
 <li>The basics of object-oriented programming, including how to create your own classes, and how to design classes for re-use.</li>
 <li>How to test programs (and, more importantly, how to design programs so that they're testable).</li>
 <li>The basic elements of version control using Subversion. (Note: roughly half of participants already know this, so we'll do this first on Thursday morning for those who don't.)</li>
 <li>Agile vs. sturdy software development practices (or, how to be productive in groups on longer timescales).</li>
 <li>How to automatically track the provenance of data (which will also serve as a wrap-up exercise).</li>
 </ol>
-<p>This workshop is meant to be highly interactive: please bring your laptop, and ask lots of questions as we go along. Since everyone seems to be using Linux or Mac, all you will need to have installed for the first day is Python 2.7.</p>
+<p>This boot camp is meant to be highly interactive: please bring your laptop, and ask lots of questions as we go along. Since everyone seems to be using Linux or Mac, all you will need to have installed for the first day is Python 2.7.</p>
 {% endblock content %}

--- a/bootcamps/2012-02-itcp.html
+++ b/bootcamps/2012-02-itcp.html
@@ -7,6 +7,6 @@
   <meta name="latlng" content="45.703255,13.718013" />
 {% endblock file_metadata %}
 {% block content %}
-<p>Software Carpentry is teaming up with the International Centre for Theoretical Physics in Trieste, Italy to hold a 2-week workshop on Scientific Software Development. The majority of the participants for this course are from developing countries.</p>
+<p>Software Carpentry is teaming up with the International Centre for Theoretical Physics in Trieste, Italy to hold a 2-week boot camp on Scientific Software Development. The majority of the participants for this course are from developing countries.</p>
 <p>The lecture materials and source code for this course can be found github at www.github.com/thehackerwithin/PyTrieste .</p>
 {% endblock content %}

--- a/bootcamps/2012-04-chicago.html
+++ b/bootcamps/2012-04-chicago.html
@@ -23,6 +23,6 @@
 <li>Debugging</li>
 <li>Documentation</li>
 </ul>
-<p><strong>Registration:</strong> Please use the form below to register your interest. We strongly encourage learners to attend with colleagues, so feel free to create or join a team when you sign up. Ideally we would like teams of 3 to 6 members, and we will give preference to teams including one more knowledgeable member who is interested in organizing further training at their own institution. By registering you are stating that you will attend both days of the workshop and participate in the online exercises and follow-up sessions in the following weeks. We will notify all applicants as to whether they have a spot no later than March 26.</p>
+<p><strong>Registration:</strong> Please use the form below to register your interest. We strongly encourage learners to attend with colleagues, so feel free to create or join a team when you sign up. Ideally we would like teams of 3 to 6 members, and we will give preference to teams including one more knowledgeable member who is interested in organizing further training at their own institution. By registering you are stating that you will attend both days of the boot camp and participate in the online exercises and follow-up sessions in the following weeks. We will notify all applicants as to whether they have a spot no later than March 26.</p>
 <p><strong>Contact:</strong> scopatz_AT_gmail.com</p>
 {% endblock content %}

--- a/bootcamps/2012-04-utahstate.html
+++ b/bootcamps/2012-04-utahstate.html
@@ -51,7 +51,7 @@ for line in my_file:
 print sum</pre>
 <p><strong>When:</strong> April 14 &amp; 15th, 2012. <strong>8:30am to 4:30pm.</strong></p>
 <p><strong>Where:</strong> Room 314 of the Biology and Natural Resources building at Utah State University, 5305 Old Main Hill, Logan, UT.</p>
-<p><strong>Information:</strong> Since 1998, Software Carpentry has taught scientists and engineers the skills and tools they need to use computing more productively. Thanks to a grant from the Sloan Foundation, we are running a two-day workshop Utah State University, followed by an optional 4-8 weeks of self-paced online learning. The workshop covers the core skills a researcher needs to know in order to be productive in a small team:</p>
+<p><strong>Information:</strong> Since 1998, Software Carpentry has taught scientists and engineers the skills and tools they need to use computing more productively. Thanks to a grant from the Sloan Foundation, we are running a two-day boot camp Utah State University, followed by an optional 4-8 weeks of self-paced online learning. The boot camp covers the core skills a researcher needs to know in order to be productive in a small team:</p>
 <ul>
 <li>Using the shell to do more in less time</li>
 <li>Using version control to manage and share information</li>
@@ -60,6 +60,6 @@ print sum</pre>
 <li>Working with relational databas</li>
 </ul>
 <p>The online follow-up goes into these topics in more detail, and also touch on program design and construction, matrix programming, using spreadsheets in a disciplined way, data management, and software development lifecycles.</p>
-<p>In collaboration with Ethan White's lab in the Department of Biology we will be offering the workshop at Utah State on the weekend of April 14th and 15th. The workshop is free, you just need to bring a laptop and commit to spending 2 days learning about how to be a better scientific programmer. Space is limited and signups are on a first come first serve basis.</p>
+<p>In collaboration with Ethan White's lab in the Department of Biology we will be offering the boot camp at Utah State on the weekend of April 14th and 15th. The boot camp is free, you just need to bring a laptop and commit to spending 2 days learning about how to be a better scientific programmer. Space is limited and signups are on a first come first serve basis.</p>
 <p>For more information, please see <a href="http://software-carpentry.org">http://software-carpentry.org</a>, or contact us by email at {{contact_email}}. You can also feel free to email Ethan (ethan.white@usu.edu) with any questions.</p>
 {% endblock content %}

--- a/bootcamps/2012-05-newcastle.html
+++ b/bootcamps/2012-05-newcastle.html
@@ -14,9 +14,9 @@
 {% include "_who.html" %}
 {% include "_requirements.html" %}
 {% include "_content.html" %}
-<p><strong>Registration:</strong> Please use this form to register your interest by April 6. We will allocate places to individuals and groups we believe will benefit, while aiming for a balance of subjects and geographical areas. We strongly encourage learners to attend with colleagues, so please create or join a team when you sign up. Ideally we would like teams of 3 to 6 members, and we will give preference to teams including one more knowledgeable member who is interested in organizing further training at their own institution. By registering you are stating that you will attend both days of the workshop and participate in the online exercises and follow-up sessions in the following weeks. We will notify all applicants as to whether they have a spot no later than April 13.</p>
+<p><strong>Registration:</strong> Please use this form to register your interest by April 6. We will allocate places to individuals and groups we believe will benefit, while aiming for a balance of subjects and geographical areas. We strongly encourage learners to attend with colleagues, so please create or join a team when you sign up. Ideally we would like teams of 3 to 6 members, and we will give preference to teams including one more knowledgeable member who is interested in organizing further training at their own institution. By registering you are stating that you will attend both days of the boot camp and participate in the online exercises and follow-up sessions in the following weeks. We will notify all applicants as to whether they have a spot no later than April 13.</p>
 <p><strong>Contact:</strong> For further information please e-mail us at swc2012@ncl.ac.uk.</p>
-<p><strong>Material from the workshop:</strong></p>
+<p><strong>Material from the boot camp:</strong></p>
 <p>Monday May 14th<br />
 <a href="{{root_path}}/files/2012/05/SC-WhatWeKnow.ppt"> What we actually know about developing software, and why we believe it's true</a> &mdash; Steve Crouch<br />
 <a href="{{root_path}}/files/2012/05/swcNCL.zip"> The bash shell</a> &mdash; Steve McGough<br />

--- a/bootcamps/2012-09-dafx.html
+++ b/bootcamps/2012-09-dafx.html
@@ -11,7 +11,7 @@
 <p><strong>When:</strong> September 13-14, 2012. We will start at 9:00 and end at 4:30 each day.</p>
 {% include "_what.html" %}
 {% include "_who.html" %}
-<p><strong>Requirements:</strong> Please see the Software Setup page for a list of the software you need to install for the workshop. The final list will also be sent to participants a week before the boot camp.</p>
+<p><strong>Requirements:</strong> Please see the Software Setup page for a list of the software you need to install for the boot camp. The final list will also be sent to participants a week before the boot camp.</p>
 {% include "_content.html" %}
 {% include "_contact.html" %}
 <p><strong>Registration is being handled by the bootcamp organizers. </strong>Please see the following page for further information (accomodation, venue details, etc.): <a title="DAFx Bootcamp" href="http://soundsoftware.ac.uk/york2012-bootcamp">http://soundsoftware.ac.uk/york2012-bootcamp</a></p>

--- a/bootcamps/2012-10-ubc.html
+++ b/bootcamps/2012-10-ubc.html
@@ -7,11 +7,11 @@
   <meta name="latlng" content="49.2617149,-123.2534305" />
 {% endblock file_metadata %}
 {% block content %}
-<p><strong>New!</strong> <a href="#install">Setup instructions</a> have been added to this page. Please make sure you go through them the day before the workshop starts, and <a href="mailto:{{contact_email}}">mail us</a> if you have problems.</p>
+<p><strong>New!</strong> <a href="#install">Setup instructions</a> have been added to this page. Please make sure you go through them the day before the boot camp starts, and <a href="mailto:{{contact_email}}">mail us</a> if you have problems.</p>
 <p><strong>Where:</strong> University of British Columbia (see EventBrite pages for buildings and rooms).</p>
 <p><strong>When:</strong> October 18-19, 2012. We will start at 9:00 and end at 4:30 each day.</p>
 {% include "_what.html" %}
-<p><strong>Note:</strong> we are running two workshops simultaneously, one using Python and another using R. Please be sure to register for the one you want.</p>
+<p><strong>Note:</strong> we are running two boot camps simultaneously, one using Python and another using R. Please be sure to register for the one you want.</p>
 {% include "_who.html" %}
 <p><strong>Content:</strong> <strong></strong>The syllabus for this boot camp will include:</p>
 <ul>
@@ -41,7 +41,7 @@
 <li>Mac: Python comes with recent version of Mac OS X, but again, you'll need to install (and sometimes compiles) scientific packages yourself. EPD is your friend.</li>
 </ul>
 <h2>R</h2>
-<p>R can be downloaded <a href="http://cran.r-project.org/">here</a>. We will use a few packages in the workshop, including lattice, plyr and data.table. Once R is installed, you can get these packages by typing the command "install.packages(<em>package.name</em>)" at the prompt, and following the instructions. Please be sure to install the knitr package this way; you will also need <a href="http://johnmacfarlane.net/pandoc/">pandoc</a> for the lesson on reproducible research.</p>
+<p>R can be downloaded <a href="http://cran.r-project.org/">here</a>. We will use a few packages in the boot camp, including lattice, plyr and data.table. Once R is installed, you can get these packages by typing the command "install.packages(<em>package.name</em>)" at the prompt, and following the instructions. Please be sure to install the knitr package this way; you will also need <a href="http://johnmacfarlane.net/pandoc/">pandoc</a> for the lesson on reproducible research.</p>
 <p>A popular text editor for R is <a href="http://rstudio.org/">R-Studio</a>. Alternatively, if you want an editor that can handle multiple languages, you might want to consider ESS (Emacs Speaks Statistics), available as a bundle <a href="http://vgoulet.act.ulaval.ca/en/emacs/">here</a>.</p>
 <h2>Bash</h2>
 <p>If you are on Linux or Mac, you already have Bash (it's what runs in a terminal window).</p>
@@ -54,7 +54,7 @@
 <ul>
 <li>Linux: Subversion comes with all sane Linux distributions.</li>
 <li>Windows: as mentioned above, you must ask for the <code>svn</code> package when installing Cygwin.</li>
-<li>For reasons beyond mere human comprehension, Apple decided to stop including Subversion with Mac OS X as of version 10.8 (Mountain Lion). If you are using an earlier version of Mac OS X, you should be able to type <code>svn</code> at a terminal prompt. If you are on Mountain Lion, you can try to download this binary and run it on your machine (try typing <code>svn</code> at a command prompt). If that doesn't work, you will need to install <a href="https://developer.apple.com/xcode/">XCode</a> (which is 1.2 GByte, so please don't leave it until the morning of the workshop).</li>
+<li>For reasons beyond mere human comprehension, Apple decided to stop including Subversion with Mac OS X as of version 10.8 (Mountain Lion). If you are using an earlier version of Mac OS X, you should be able to type <code>svn</code> at a terminal prompt. If you are on Mountain Lion, you can try to download this binary and run it on your machine (try typing <code>svn</code> at a command prompt). If that doesn't work, you will need to install <a href="https://developer.apple.com/xcode/">XCode</a> (which is 1.2 GByte, so please don't leave it until the morning of the boot camp).</li>
 </ul>
 <h2>Testing the installed software</h2>
 <p>We recommend that you try the following simple tests to ensure that everything is installed and working correctly before the course starts.</p>

--- a/bootcamps/2013-01-ubc-r-advanced.html
+++ b/bootcamps/2013-01-ubc-r-advanced.html
@@ -27,5 +27,5 @@
 </p>
 {% include "_requirements.html" %}
 {% include "_contact.html" %}
-<p>Participation in this workshop is by invitation.</p>
+<p>Participation in this boot camp is by invitation.</p>
 {% endblock content %}

--- a/bootcamps/2013-01-ubc-r-beginners.html
+++ b/bootcamps/2013-01-ubc-r-beginners.html
@@ -22,5 +22,5 @@
 </p>
 {% include "_requirements.html" %}
 {% include "_contact.html" %}
-<p>Participation in this workshop is by invitation.</p>
+<p>Participation in this boot camp is by invitation.</p>
 {% endblock content %}

--- a/bootcamps/2013-02-amos.html
+++ b/bootcamps/2013-02-amos.html
@@ -52,7 +52,7 @@ University of Melbourne, who will circulate the room and answer any
 questions that you might have.</p>
 
 <p><strong>Laptops:</strong> Participants are required to bring their 
-own laptop, as the workshop involves a mixture of lectures and hands on 
+own laptop, as the boot camp involves a mixture of lectures and hands on 
 exercises. The lecture theatre has desk facilities where you can plug in
  and charge. If you don't have a laptop, don't stress, we'll pair you up
  with someone who does.</p>

--- a/bootcamps/2013-03-utahstate.html
+++ b/bootcamps/2013-03-utahstate.html
@@ -11,7 +11,7 @@
 {% block content %}
 <p><strong>Where:</strong> Room 314 of the Biology and Natural Resources building at Utah State University, 5305 Old Main Hill, Logan, UT.</p>
 <p><strong>When:</strong> March 23-24, 2013. <strong> 9:00am to 4:30pm</strong></p>
-<p><strong>Information:</strong> Since 1998, Software Carpentry has taught scientists and engineers the skills and tools they need to use computing more productively. Thanks to a grant from the Sloan Foundation, we are running a two-day workshop at Utah State University, followed by an optional 4-8 weeks of self-paced online learning. The workshop covers the core skills a researcher needs to know in order to be productive in a small team:</p>
+<p><strong>Information:</strong> Since 1998, Software Carpentry has taught scientists and engineers the skills and tools they need to use computing more productively. Thanks to a grant from the Sloan Foundation, we are running a two-day boot camp at Utah State University, followed by an optional 4-8 weeks of self-paced online learning. The boot camp covers the core skills a researcher needs to know in order to be productive in a small team:</p>
 <ul>
 <li>Using the shell to do more in less time</li>
 <li>Using version control to manage and share information</li>
@@ -20,7 +20,7 @@
 <li>Working with relational databases</li>
 </ul>
 <p>The online follow-up goes into these topics in more detail, and also touch on program design and construction, matrix programming, using spreadsheets in a disciplined way, data management, and software development lifecycles.</p>
-<p>In collaboration with <a href="http://whitelab.weecology.org/">Ethan White's lab</a> in the <a href="http://www.biology.usu.edu/">Department of Biology</a> we will be offering the workshop at Utah State on the weekend of March 23rd and 24th. The workshop is free, you just need to bring a laptop and commit to spending 2 days learning about how to be a better scientific programmer. Space is limited and signups are on a first come first serve basis.</p>
+<p>In collaboration with <a href="http://whitelab.weecology.org/">Ethan White's lab</a> in the <a href="http://www.biology.usu.edu/">Department of Biology</a> we will be offering the boot camp at Utah State on the weekend of March 23rd and 24th. The boot camp is free, you just need to bring a laptop and commit to spending 2 days learning about how to be a better scientific programmer. Space is limited and signups are on a first come first serve basis.</p>
 <p>For more information, please see <a href="http://software-carpentry.org">http://software-carpentry.org</a>, or contact us by email at {{contact_email}}. You can also feel free to email Ethan (ethan.white@usu.edu) or Dan McGlinn (daniel.mcglinn@usu.edu) with any questions.</p>
 {{eventbrite(page.eventbrite_key, page.venue, page.date)}}
 {% endblock content %}

--- a/bootcamps/2013-05-geomar.html
+++ b/bootcamps/2013-05-geomar.html
@@ -60,7 +60,7 @@
   </li>
 </ul>
 <p>At the end of day two you will be able to write a Python script that conducts all of the tasks of day one in one go.</p>
-<p><strong>Laptops:</strong> Participants are required to bring their own laptop, as the workshop involves a mixture of lectures and hands on exercises. The lecture theatre has desk facilities where you can plug in and charge. If you don't have a laptop, don't stress, we'll pair you up with someone who does.</p>
+<p><strong>Laptops:</strong> Participants are required to bring their own laptop, as the boot camp involves a mixture of lectures and hands on exercises. The lecture theatre has desk facilities where you can plug in and charge. If you don't have a laptop, don't stress, we'll pair you up with someone who does.</p>
 {% include "_contact.html" %}
 {{eventbrite(page.eventbrite_key, page.venue, page.date)}}
 {% endblock content %}

--- a/bootcamps/how-to.html
+++ b/bootcamps/how-to.html
@@ -8,8 +8,7 @@
 {% block content %}
 
 <p>
-  A boot camp is a workshop during which participants learn software skills based on shorts tutorials and hands-on practical exercises.
-  A typical boot camp runs over 2 days with 20-50 attendees, 2-3 instructors, and at least one helper for every 10 attendees.
+  A boot camp is an intensive hands-on workshop during which participants learn software skills based on shorts tutorials and practical exercises. A typical boot camp runs over 2 days with 20-50 attendees, 2-3 instructors, and at least one helper for every 10 attendees.
 </p>
 
 <p>
@@ -38,22 +37,22 @@
   <h3>1. Decide what sort of boot camp you'll run</h3>
 
   <p>
-    Be clear what sort of workshop you will run.
+    Be clear what sort of boot camp you will run.
     Can anyone apply or is it restricted to a specific university or company?
     You'll need to decide this very early on and then stick to it,
-    because the type of workshop you host will drive many of your other decisions:
+    because the type of boot camp you host will drive many of your other decisions:
     from the topics covered, to the room used, to how you plan any follow-up sessions.
   </p>
 
   <p>
     There are pros and cons either way.
-    A closed workshop can be more easily tailored to a specific audience,
+    A closed boot camp can be more easily tailored to a specific audience,
     the attendees are more likely to know one another and follow-ups will be easier.
-    On the other hand, you won't have any problems populating an open workshop.
+    On the other hand, you won't have any problems populating an open boot camp.
   </p>
 
   <p>
-    If you choose a closed workshop,
+    If you choose a closed boot camp,
     beware that boot camps are so popular you will have to continuously resist people who will try to persuade you to open it up.
     If you've got good reasons to keep it closed or invite-only,
     keep it that way.
@@ -261,7 +260,7 @@
 
     <p><strong>Registration:</strong> Please use this form to register your interest by April 6. We will allocate places to individuals and groups we believe will benefit, while aiming for a balance of subjects and geographical areas. We strongly encourage learners to attend with colleagues, so please create or join a team when you sign up. Ideally we would like teams of 3 to 6 members, and we will give preference to teams including one more knowledgeable member who is interested in organizing further training at their own institution.</p>
 
-    <p>There is no charge to attend, however, by registering you are stating that you will attend both days of the workshop and participate in the online exercises and follow-up sessions in the following weeks.</p>
+    <p>There is no charge to attend, however, by registering you are stating that you will attend both days of the boot camp and participate in the online exercises and follow-up sessions in the following weeks.</p>
 
     <p>We will notify all applicants as to whether they have a spot no later than April 13.</p>
 
@@ -659,7 +658,7 @@
   <p>
     And remember: feedback is pointless if you don't pay attention to it (or worse, if you explain it away).
     There's no point using minute cards if you don't bother to read them until the boot camp is over,
-    and no point collecting feedback after each workshop if you don't change what and how you teach to reflect it.
+    and no point collecting feedback after each boot camp if you don't change what and how you teach to reflect it.
   </p>
 
   <h3>Don't master the material yourself.</h3>


### PR DESCRIPTION
This patch makes terminology more consistent by replacing the word 'workshop' with the word 'boot camp' in most places: most rather than all, because there are places where we say, "A boot camp is a two-day workshop" (or something like that).
