### PR TITLE
Remove reference to Cygwin under MacOS

### DIFF
--- a/setup/terminal.html
+++ b/setup/terminal.html
@@ -20,7 +20,7 @@
 <p>Or browse using Windows Explorer to <code>C:\cygwin\bin\</code> and double-click on <code>mintty.exe</code>. You should see a terminal window like,</p>
 <p><img src="{{root_path}}/files/2012/10/cygwin-terminal-300x175.jpg" alt="Cygwin terminal" /></p>
 <p>Your home directory&mdash;the one the Cygwin Terminal defaults to&mdash;can be found at <code>C:\cygwin\home\user\</code>.</p>
-<p><strong>To get a terminal window in Cygwin under MacOSX:</strong></p>
+<p><strong>To get a terminal window in Apple's OS X:</strong></p>
 <p>Browse into the <strong>Applications</strong> folder, then into the <strong>Utilities</strong> folder and open the Terminal application. You should see a terminal window like,</p>
 <p><img src="{{root_path}}/files/2012/10/mac-terminal-300x257.jpg" alt="Mac terminal" /></p>
 <p>Your &#8220;home&#8221; directory &#8211; the one the terminal defaults to &#8211; can be found at <code>/Users/user</code>.</p>


### PR DESCRIPTION
In http://software-carpentry.org/setup/terminal.html, change "To get a terminal window in Cygwin under MacOSX" header to "To get a terminal window in MacOS X". (It's not Cygwin.)
