### PR TITLE
Blog post with feedback from LBL second round

### DIFF
--- a/blog/2013/03/second-round-at-lawrence-berkeley.html
+++ b/blog/2013/03/second-round-at-lawrence-berkeley.html
@@ -1,0 +1,68 @@
+{% extends "_blog.html" %}
+{% block file_metadata %}
+<meta name="post_id" content="5413" />
+<meta name="author_id" content="kitzes.j" />
+<meta name="title" content="Second Round at Lawrence Berkeley" />
+<meta name="post_date" content="2013-03-13" />
+<meta name="category" content="boot-camp" />
+<meta name="category" content="venues/lawrence-berkeley-lab" />
+{% endblock file_metadata %}
+{% block content %}
+<p>Last week we finished up our second workshop at Lawrence Berkeley Lab. This 
+time around, we tried a more free-form version of the feedback exercise in 
+which students live-typed their feedback into an <a href="http://etherpad.mozilla.org">Etherpad</a>
+at the end of each day. This went very well, as 
+it gave us time to gather unique comments, get a rough idea of the amount of 
+support for each comment, and to respond to some of the comments in real time. 
+We asked three questions: what was good, what was bad/confusing, and what we 
+didn't do or talk about that we should have.</p>
+
+<p><strong>The Good</strong></p>
+<ul>
+	<li>Introduction to python and how to install things with command lines</li>
+	<li>Understanding python objects, classes, functions, methods, etc.</li>
+	<li>Thinking about how to structure the directories for a project</li>
+	<li>Hearing how regular Python users use Python (+1)</li>
+	<li>Just getting finally to write some .py code!</li>
+	<li>Real world example-driven exercises</li>
+	<li>Knowledge of helpful data types in Python</li>
+	<li>iPython notebook and Etherpad are amazing (+1)</li>
+	<li>The party on the Etherpad !!!!! (+1 +1) [Ed: the students had some fun "passing notes" in the Etherpad]</li>
+	<li>Patient, fast, specific help (+1)</li>
+	<li>An explanation of git from people who use git (+1 +1 +1)</li>
+	<li>Inside structure of git</li>
+	<li>You put a lot of things in my brain in a very short time (+1)</li>
+	<li>Standalone scripts is my new goal for my code!</li>
+	<li>Start thinking about how to test code for reusability</li>
+	<li>Danish and coffee / snacks / food juice</li>
+</ul>
+
+<p><strong>The Bad or Confusing</strong></p>
+<ul>
+	<li>Python version issues, especially multiple Python versions on same system (+1 +1 +1)</li>
+	<li>Relationship between Anaconda/IPython/Enthought/system Python</li>
+	<li>Use of iPython Notebook vs console, roles in real-world code development (+1)</li>
+	<li>Glossary/handout on Python would have been helpful for beginners</li>
+	<li>Most of the Unix tutorial was extremely basic (+1 +1 +1) [Ed: There were two follow ups to this comment in which students said they needed the basic tutorial badly.]</li>
+	<li>Worrying about whether to abandon perl and R for python - then I'd have to start the learning curve all over.</li>
+	<li>Too fast for beginners, but noticed that others were bored (+1)</li>
+	<li>Not enough 'signposting' during talks/lessons</li>
+	<li>It's over now :\</li>
+</ul>
+
+<p><strong>Things We Didn't Do or Talk About But Should Have</strong></p>
+<ul>
+	<li>Online "getting started with Unix" tutorial before class (+1 +1 +1)</li>
+	<li>Making and annotating/labelling plots, more Matplotlib (+1 +1)</li>
+	<li>Discussion of computational and memory efficiency</li>
+	<li>"Best practices" for developing and maintaining code (+1 +1 +1 +1)</li>
+	<li>Fitting data (+1 +1)</li>
+	<li>How to share code, etc. with those who don't use version control</li>
+	<li>Working with specific types of data (ie, DNA)</li>
+	<li>More about modules and importing, common bugs, etc.</li>
+	<li>Is there a better way to find help than google and stackoverflow?</li>
+	<li>Overhead when working with extremeley large data sets</li>
+</ul>
+
+<p>Thanks to Shreyas Cholia and to instructors Matthew Brett, Cindee Madison, and Ariel Rokem and helpers Paul Ivanov and Matt Terry.</p>
+{% endblock content %}

--- a/blog/metadata.json
+++ b/blog/metadata.json
@@ -15,6 +15,7 @@
         "hart.t" : "Ted Hart",
         "huff.k" : "Katy Huff",
         "jackson.m" : "Mike Jackson",
+	"kitzes.j" : "Justin Kitzes",
         "lawson.a" : "Ainsley Lawson",
         "limare.n" : "Nicolas Limare",
         "mcglinn.d" : "Dan McGlinn",


### PR DESCRIPTION
Also added myself as an author to metadata.json.

I'm getting a whole slew of errors when I run `make check` in either my modified or a clean clone of this repo. They appear to be associated with all of the blog post pages, and all look generally like the following:

```
errors in /Users/jkitzes/Projects/swc/website/build/blog/2012/03/boot-camp-in-paris-june-28-29-2012.html
((16, 84), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((21, 73), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((22, 76), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((23, 84), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((24, 73), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((25, 83), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((26, 157), 'non-void-element-with-trailing-solidus', {'name': u'link'})
((27, 70), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((35, 38), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((36, 46), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((37, 44), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((38, 67), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((39, 44), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((40, 53), 'non-void-element-with-trailing-solidus', {'name': u'meta'})
((51, 98), 'non-void-element-with-trailing-solidus', {'name': u'img'})
((151, 103), 'non-void-element-with-trailing-solidus', {'name': u'input'})
((152, 84), 'non-void-element-with-trailing-solidus', {'name': u'input'})
((153, 17), 'unexpected-end-tag', {'name': 'form'})
((154, 14), 'end-tag-too-early', {'name': u'div'})
```

I'm mentioning this here in case this has any bearing on merging the pull (I don't see any obvious errors in the build) - but if not, I can move it to Issue Tracker.

[Edit: Issue is somewhere in `make check-links`, if that wasn't obvious...]
