### PR TITLE
Marking 'full' boot camps as such in the table and map

### DIFF
--- a/bootcamps/2013-03-kaust.html
+++ b/bootcamps/2013-03-kaust.html
@@ -5,6 +5,7 @@
   <meta name="startdate" content="2013-03-24" />
   <meta name="enddate" content="2013-03-25" />
   <meta name="latlng" content="22.3101,39.1259" />
+  <meta name="registration" content="full" />
 {% endblock file_metadata %}
 {% block content %}
 <p><strong>Where:</strong> Library Computer Laboratory, King Abdullah University of Science and Technology.</p>

--- a/bootcamps/index.html
+++ b/bootcamps/index.html
@@ -41,8 +41,9 @@
     };
 
     var oldPin = MarkerPin("FE7569");
-    var newPin = MarkerPin("69FE86");
-    var newRestrictedPin = MarkerPin("6975FE");
+    var openPin = MarkerPin("69FE86");
+    var fullPin = MarkerPin("FEFE69");
+    var restrictedPin = MarkerPin("6975FE");
 
     var pinShadow = new google.maps.MarkerImage(
         "http://chart.apis.google.com/chart?chst=d_map_pin_shadow",
@@ -65,9 +66,11 @@
         title: "{{bootcamp.venue}}, {{bootcamp.date}}",
     {% if bootcamp.startdate >= today %}
       {% if bootcamp.registration == 'restricted' %}
-        icon: newRestrictedPin,
+        icon: restrictedPin,
+      {% elif bootcamp.registration == 'full' %}
+        icon: fullPin,
       {% else %}
-        icon: newPin,
+        icon: openPin,
       {% endif %}
         visible: true,
     {% else %}
@@ -183,13 +186,16 @@
 <div style="margin-bottom: 20px;">
   <p>
     <img src="http://chart.apis.google.com/chart?chst=d_map_pin_letter&amp;chld=%E2%80%A2|69FE86" />
-    upcoming open boot camps
+    open
+    |
+    <img src="http://chart.apis.google.com/chart?chst=d_map_pin_letter&amp;chld=%E2%80%A2|FEFE69" />
+    full
     |
     <img src="http://chart.apis.google.com/chart?chst=d_map_pin_letter&amp;chld=%E2%80%A2|6975FE" />
-    upcoming restricted boot camps
+    restricted
     |
     <img src="http://chart.apis.google.com/chart?chst=d_map_pin_letter&amp;chld=%E2%80%A2|FE7569" />
-    past boot camps
+    past
   </p>
 </div>
 


### PR DESCRIPTION
1. bootcamps/index.html now knows how to display 'full' as well as 'open', 'restricted', and 'past' bootcamps.
2. The KAUST bootcamp is now marked as 'full'.
