### PR TITLE
Removing note about online office hours from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,6 @@
       <a href="{{root_path}}/bootcamps/index.html#calendar">our calendar</a>
       to find a boot camp near you.
     </p>
-    <div class="well well-small">
-      <i class="icon-circle-arrow-right"></i> We also offer <a
-      href="{{root_path}}/bootcamps/office-hours.html">online office hours</a>
-      for help with your day-to-day computing tasks.
-    </div>
 
     <h4>Learn Online</h4>
     <p>


### PR DESCRIPTION
Because we're retiring these.
