### PR TITLE
Adding links to other mailing lists to our 'contributing' page

### DIFF
--- a/about/contributing.html
+++ b/about/contributing.html
@@ -31,23 +31,32 @@ help to grow, and you can contribute in many ways, large and small.</p>
     provide you with training or advice.</p>
   </dd>
 
+  <dt id="fix">Fix</dt>
+  <dd>
+    <p>If you see a mistake in on our website, please add a comment to the
+    appropriate page, or <a href="mailto:{{contact_email}}">mail us</a>, and
+    we'll fix it as quickly as we can.  And of course, we always welcome
+    pull requests (see below).</p>
+  </dd>
+
   <dt id="create">Create</dt>
   <dd>
-    <p>If you are interested in developing the Software Carpentry content, you
-    can use  <a href="http://git-scm.com/">Git</a> to get the source for our <a
-    href="https://github.com/swcarpentry/website">website</a>, and our <a
-    href="https://github.com/swcarpentry/boot-camps">bootcamp teaching
-    materials</a>. We welcome any pull requests.</p>
-
-    <p>Drop us a line by sending us <a href="mailto:{{contact_email}}">email</a>
-    and/or joining the discussion list (see below) so that we can
-    coordinate.</p> 
+    <p>If you are interested in developing the Software Carpentry
+    content, you can use <a href="http://git-scm.com/">Git</a> to get
+    the source for
+    our <a href="https://github.com/swcarpentry/website">website</a>,
+    and
+    our <a href="https://github.com/swcarpentry/boot-camps">teaching
+    materials</a>.  Pull requests for both are always welcome, or
+    us <a href="mailto:{{contact_email}}">mail us</a> to talk about
+    what you'd like to do and how we can help.</p>
   </dd>
+
   <dt id="discuss">Discuss</dt>
   <dd>
     <p>To stay up to date with us, you can follow <a
-    href="{{root_path}}/blog">our blog</a> and sign up for our low-traffic (~1-4
-    emails a month) announcement mailing list:</p>
+    href="{{root_path}}/blog">our blog</a> and sign up for our low-traffic
+    announcement mailing list (approximately 2-3 emails a month):</p>
     <form class="form-inline" method="post" style="text-align:center"
       action="http://scripts.dreamhost.com/add_list.cgi">
       <fieldset>
@@ -62,16 +71,56 @@ help to grow, and you can contribute in many ways, large and small.</p>
           Unsubscribe</button>
       </fieldset>
     </form>
+    <p>We also run these higher-traffic mailing lists:</p>
+    <table class="table table-striped">
+      <tr>
+        <td>
+          <a href="http://lists.software-carpentry.org/listinfo.cgi/discuss-software-carpentry.org">discuss</a>
+        </td>
+        <td>
+          The main channel for discussion of direction and technology.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="http://lists.software-carpentry.org/listinfo.cgi/assessment-software-carpentry.org">assessment</a>
+        </td>
+        <td>
+          Where we talk about how to assess what learners already know,
+          what they've learned from us,
+          and what impact we've had.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="http://lists.software-carpentry.org/listinfo.cgi/data-software-carpentry.org">data</a>
+        </td>
+        <td>
+          For discussion of a new "data carpentry" module.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="http://lists.software-carpentry.org/listinfo.cgi/tutors-software-carpentry.org">tutors</a>
+        </td>
+        <td>
+          A by-invitation list used to match instructors to boot camps.
+        </td>
+      </tr>
+    </table>
+  </dd>
 
-    <p>Additionally, you can join our higher-traffic <a
-    href="http://lists.software-carpentry.org/listinfo.cgi/discuss-software-carpentry.org">discussion
-    list</a>. This is the main avenue through which instructors and and other
-    volunteers discuss course material changes, technology, and make planning
-    decisions.</p>
-
-    <p>If you see a mistake in on our website, please add a comment to the
-    appropriate page, or <a href="mailto:{{contact_email}}">mail us</a>, and
-    we'll fix it as quickly as we can.</p>
+  <dt id="learn">Learn</dt>
+  <dd>
+    <p>
+      We run an online training course to help people become
+      instructors.  The course requires 2-4 hours/week for 8-10 weeks,
+      and covers the basics of educational psychology, instructional
+      design, and how to apply both to teaching programming to
+      scientists.  To find out more,
+      visit <a href="http://teaching.software-carpentry.org">the
+      course website</a>.
+    </p>
   </dd>
 </dl>
 {% endblock content %}

--- a/about/contributing.html
+++ b/about/contributing.html
@@ -48,7 +48,7 @@ help to grow, and you can contribute in many ways, large and small.</p>
     and
     our <a href="https://github.com/swcarpentry/boot-camps">teaching
     materials</a>.  Pull requests for both are always welcome, or
-    us <a href="mailto:{{contact_email}}">mail us</a> to talk about
+    <a href="mailto:{{contact_email}}">mail us</a> to talk about
     what you'd like to do and how we can help.</p>
   </dd>
 


### PR DESCRIPTION
The 'contributing' page now has links to all our lists.
