### PR TITLE
Adding a page for collaborations

### DIFF
--- a/_base.html
+++ b/_base.html
@@ -180,6 +180,7 @@
                 <li><a href="{{root_path}}/about/credits.html">Sponsors</a></li>
                 <li><a href="{{root_path}}/about/team.html">Team</a></li>
                 <li><a href="{{root_path}}/about/contributing.html">Contributing</a></li>
+                <li><a href="{{root_path}}/about/collaborating.html">Collaborating</a></li>
                 <li><a href="{{root_path}}/about/audience.html">Our Audience</a></li>
                 <li><a href="{{root_path}}/about/biblio.html">Readings</a></li>
               </ul>

--- a/about/collaborating.html
+++ b/about/collaborating.html
@@ -1,0 +1,41 @@
+{% extends "_base.html" %}
+{% block file_metadata %}
+  <meta name="title" content="Collaborations" />
+{% endblock file_metadata %}
+{% block navhighlight %}{{navhighlight('about')}}{% endblock navhighlight %}
+{% block content %}
+<p>
+  Software Carpentry is actively seeking ways to partner with other groups and initiatives
+  to help change what scientists do and how they do it.
+</p>
+
+<h2>EPSRC-Approved Software Training for Centres of Doctoral Training</h2>
+<p>
+  The <a href="http://www.software.ac.uk">Software Sustainability Institute</a>
+  was <a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/H043160/1">founded by the EPSRC</a>
+  as a national facility for cultivating world-class research through software.
+  Based at the universities of Edinburgh, Manchester, Oxford and Southampton,
+  it is an EPSRC-approved supplier of training for the Centres for Doctoral Training (CDT) call.
+  Its training packages are based on Software Carpentry,
+  and its training packages include instructors who will travel to your organisation and present the course,
+  a curriculum tailored to your requirements,
+  and administration of the training event,
+  from booking rooms to organising refreshments.
+</p>
+<p>
+  The EPSRC has recognised the fundamental importance of software in research,
+  and the necessity of good software development practices in producing accurate, reusable, and reproducible research.
+  The <a href="http://www.software.ac.uk">SSI</a>'s training courses
+  make it easy to meet the EPSRC's software-development requirements
+  without investing resources into creating new training,
+  and without duplicating existing training materials and courses.
+</p>
+<p>
+  For more information about how you can include the <a href="http://www.software.ac.uk">SSI</a>'s training
+  in your CDT bid,
+  please see <a href="http://www.software.ac.uk/Training-For-CDTs">the full description</a>
+  of what they offer,
+  or contact the <a href="http://www.software.ac.uk">SSI</a>'s director,
+  <a href="mailto:n.chuehong@software.ac.uk">Dr. Neil Chue Hong</a>.
+</p>
+{% endblock content %}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="subfile" content="about/90seconds.html" />
   <meta name="subfile" content="about/audience.html" />
   <meta name="subfile" content="about/biblio.html" />
+  <meta name="subfile" content="about/collaborating.html" />
   <meta name="subfile" content="about/contributing.html" />
   <meta name="subfile" content="about/credits.html" />
   <meta name="subfile" content="about/faq.html" />


### PR DESCRIPTION
1. Adding a page to the web site to describe our collaborations (currently only one, with the SSI).
2. Adding a link to it in the general menu in the _base.html template page.
3. Adding a meta to it in the root index page to include it in the build.
