### PR TITLE
Putting sponsor information in 'include' files so it can be re-used in boot camp pages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COMPILE = \
 	python bin/compile.py \
 	-d $$(date "+%Y-%m-%d") \
 	-o $(OUT_DIR) \
-	-p . -p bootcamps -p 3_0 -p 4_0 -p blog \
+	-p . -p bootcamps -p sponsors -p 3_0 -p 4_0 -p blog \
 	-s $(SITE) \
 	-v
 

--- a/about/credits.html
+++ b/about/credits.html
@@ -10,125 +10,39 @@
 <section>
   <h2>Version 5</h2>
   <p>We are very grateful for the ongoing support of:</p>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/sloan.png" alt="Sloan Foundation" />
-    <div class="media-body">The <strong>Alfred P. Sloan Foundation</strong>, a
-    philanthropic, not-for-profit grantmaking institution established in 1934.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/mozilla.png" />
-    <div class="media-body">The <strong>Mozilla Foundation</strong>, a
-    non-profit organization that promotes openness, innovation and
-    participation on the Internet.
-  </div></div>
+  {% include "sloan.html" %}
+  {% include "mozilla.html" %}
 </section>
 
 <section>
   <h2>Version 4</h2>
   <p>Work on Version 4 (May 2010-April 2011) was made possible by the generosity of the following donors:</p>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/enthought.png" alt="Enthought" />
-    <div class="media-body"><strong>Enthought Scientific Computing</strong>'s
-    mission is to significantly improve the way scientific computing is
-    accomplished by providing powerful tools for quantitative data analysis
-    and visualization.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/indiana-u.jpg" alt="Indiana University" />
-    <div class="media-body">The <strong>Indiana University</strong> School of
-    Informatics and Computing is nationally recognized for excellence and
-    leadership in Informatics programs, including undergraduate and graduate
-    education, research, placement and outreach.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/michigan-state.jpg" alt="Michigan State University" />
-    <div class="media-body">The Gene Expression in Disease and Development
-    Focus Group at <strong>Michigan State University</strong> is interested in
-    training graduate students and post-docs in the latest bioinformatics
-    techniques, and advancing the state of the art in genomic analysis.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/microsoft.png" alt="Microsoft" />
-    <div class="media-body"><strong>Microsoft Corporation</strong> is the
-    manufacturer of the most widely used software in the world. Its products
-    are used worldwide by all kinds of people, on all kinds of computers, for
-    all kinds of things.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/mitacs.jpg" alt="MITACS" />
-    <div class="media-body"><strong>MITACS</strong> is a national research
-    network which connects academia with industry, government and
-    not-for-profits through short and longer-term research projects.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/qmul.gif" alt="Queen Mary University London" />
-    <div class="media-body">The Centre for Digital Music (C4DM)
-    at <strong>Queen Mary University London</strong> is a world-leading
-    multidisciplinary research group in the field of Music &amp; Audio
-    Technology. This activity is funded by EPSRC Grant EP/H043101/1.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/scimatic.png" alt="Scimatic Software" />
-    <div class="media-body"><strong>Scimatic Software</strong> is a
-    Toronto-based company that specializes in the development of software for
-    the scientific community.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/scinet.jpg" alt="SciNet" />
-    <div class="media-body"><strong>SciNet</strong> is a High Performance
-    Computing consortium based at the University of Toronto which operates
-    Canada's largest supercomputer with 30,000 cores and supports researchers
-    in a wide variety of disciplines from across the country.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/sharcnet.jpg" alt="SHARCNET" />
-    <div class="media-body"><strong>SHARCNET</strong> is a leading provider of
-    HPC infrastructure and services for the advancement of world-class
-    research and the training of computationally-expert individuals.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/ssi.png" alt="Software Sustainability Institute" />
-    <div class="media-body">The <strong>Software Sustainability
-    Institute</strong> works with researchers to ensure the useful longevity
-    of research software.
-  </div></div>
-
-  <div class="media">
-    <img class="media-object pull-left" src="{{root_path}}/img/credits/ukmo.jpg" alt="UK Met Office" />
-    <div class="media-body">The <strong>Met Office</strong> is the national
-    meteorological service for the United Kingdom, providing quality
-    meteorological and related services for the Government, the public, the
-    armed forces, aviation and commercial customers.
-  </div></div>
-
+  {% include "enthought.html" %}
+  {% include "indiana-u.html" %}
+  {% include "michigan-state.html" %}
+  {% include "microsoft.html" %}
+  {% include "mitacs.html" %}
+  {% include "qmul.html" %}
+  {% include "scimatic.html" %}
+  {% include "scinet.html" %}
+  {% include "sharcnet.html" %}
+  {% include "ssi.html" %}
+  {% include "ukmo.html" %}
 </section>
 
 <section>
   <h2>Earlier Versions</h2>
-
-  <p>We would like to thank <a href="http://www.mathworks.com">The
-  MathWorks</a>, the <a href="http://www.utoronto.ca">University of
-  Toronto</a>, the <a href="http://www.python.org/psf/">Python Software
-  Foundation</a>, and <a href="http://www.lanl.gov">Los Alamos National
-  Laboratory</a>, whose support over the years has allowed us to help
-  thousands of scientists use computers more productively.  We would also like
-  to thank Brent Gorda, who helped create and deliver the first version of
-  this course back in 1998.</p>
-
+  <p>
+    We would like to thank
+    <a href="http://www.mathworks.com">The MathWorks</a>,
+    the <a href="http://www.utoronto.ca">University of Toronto</a>,
+    the <a href="http://www.python.org/psf/">Python Software Foundation</a>,
+    and <a href="http://www.lanl.gov">Los Alamos National Laboratory</a>,
+    whose support over the years has allowed us to help
+    thousands of scientists use computers more productively.  We would also like
+    to thank Brent Gorda, who helped create and deliver the first version of
+    this course back in 1998.
+  </p>
 </section>
-
 {% endblock content %}
-
 {% block comments %}{% endblock comments %}

--- a/sponsors/enthought.html
+++ b/sponsors/enthought.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/enthought.png" alt="Enthought" />
+  <div class="media-body">
+    <strong>Enthought Scientific Computing</strong>'s
+    mission is to significantly improve the way scientific computing is
+    accomplished by providing powerful tools for quantitative data analysis
+    and visualization.
+  </div>
+</div>

--- a/sponsors/indiana-u.html
+++ b/sponsors/indiana-u.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/indiana-u.jpg" alt="Indiana University" />
+  <div class="media-body">
+    The <strong>Indiana University</strong> School of
+    Informatics and Computing is nationally recognized for excellence and
+    leadership in Informatics programs, including undergraduate and graduate
+    education, research, placement and outreach.
+  </div>
+</div>

--- a/sponsors/michigan-state.html
+++ b/sponsors/michigan-state.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/michigan-state.jpg" alt="Michigan State University" />
+  <div class="media-body">
+    The Gene Expression in Disease and Development
+    Focus Group at <strong>Michigan State University</strong> is interested in
+    training graduate students and post-docs in the latest bioinformatics
+    techniques, and advancing the state of the art in genomic analysis.
+  </div>
+</div>

--- a/sponsors/microsoft.html
+++ b/sponsors/microsoft.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/microsoft.png" alt="Microsoft" />
+  <div class="media-body">
+    <strong>Microsoft Corporation</strong> is the
+    manufacturer of the most widely used software in the world. Its products
+    are used worldwide by all kinds of people, on all kinds of computers, for
+    all kinds of things.
+  </div>
+</div>

--- a/sponsors/mitacs.html
+++ b/sponsors/mitacs.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/mitacs.jpg" alt="MITACS" />
+  <div class="media-body">
+    <strong>MITACS</strong> is a national research
+    network which connects academia with industry, government and
+    not-for-profits through short and longer-term research projects.
+  </div>
+</div>

--- a/sponsors/mozilla.html
+++ b/sponsors/mozilla.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/mozilla.png" />
+  <div class="media-body">
+    The <strong>Mozilla Foundation</strong>, a
+    non-profit organization that promotes openness, innovation and
+    participation on the Internet.
+  </div>
+</div>

--- a/sponsors/qmul.html
+++ b/sponsors/qmul.html
@@ -1,0 +1,9 @@
+  <div class="media">
+    <img class="media-object pull-left" src="{{root_path}}/img/credits/qmul.gif" alt="Queen Mary University London" />
+    <div class="media-body">
+      The Centre for Digital Music (C4DM)
+      at <strong>Queen Mary University London</strong> is a world-leading
+      multidisciplinary research group in the field of Music &amp; Audio
+      Technology. This activity is funded by EPSRC Grant EP/H043101/1.
+  </div>
+</div>

--- a/sponsors/scimatic.html
+++ b/sponsors/scimatic.html
@@ -1,0 +1,8 @@
+  <div class="media">
+    <img class="media-object pull-left" src="{{root_path}}/img/credits/scimatic.png" alt="Scimatic Software" />
+    <div class="media-body">
+      <strong>Scimatic Software</strong> is a
+      Toronto-based company that specializes in the development of software for
+      the scientific community.
+  </div>
+</div>

--- a/sponsors/scinet.html
+++ b/sponsors/scinet.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/scinet.jpg" alt="SciNet" />
+  <div class="media-body">
+    <strong>SciNet</strong> is a High Performance
+    Computing consortium based at the University of Toronto which operates
+    Canada's largest supercomputer with 30,000 cores and supports researchers
+    in a wide variety of disciplines from across the country.
+  </div>
+</div>

--- a/sponsors/sharcnet.html
+++ b/sponsors/sharcnet.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/sharcnet.jpg" alt="SHARCNET" />
+  <div class="media-body">
+    <strong>SHARCNET</strong> is a leading provider of
+    HPC infrastructure and services for the advancement of world-class
+    research and the training of computationally-expert individuals.
+  </div>
+</div>

--- a/sponsors/sloan.html
+++ b/sponsors/sloan.html
@@ -1,0 +1,7 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/sloan.png" alt="Sloan Foundation" />
+  <div class="media-body">
+    The <strong>Alfred P. Sloan Foundation</strong>, a
+    philanthropic, not-for-profit grantmaking institution established in 1934.
+  </div>
+</div>

--- a/sponsors/ssi.html
+++ b/sponsors/ssi.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/ssi.png" alt="Software Sustainability Institute" />
+    <div class="media-body">
+      The <strong>Software Sustainability Institute</strong> works
+      with researchers to ensure the useful longevity of research
+      software.
+  </div>
+</div>

--- a/sponsors/ukmo.html
+++ b/sponsors/ukmo.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/credits/ukmo.jpg" alt="UK Met Office" />
+  <div class="media-body">
+    The <strong>Met Office</strong> is the national meteorological
+    service for the United Kingdom, providing quality meteorological
+    and related services for the Government, the public, the armed
+    forces, aviation and commercial customers.
+  </div>
+</div>


### PR DESCRIPTION
We sometimes need to include blurbs about sponsors in boot camp pages (e.g., the upcoming WiSE camp's page), so separating them into include files.
