### PR TITLE
Moving descriptions of people into separate 'include' files so they can be re-used in boot camp pages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COMPILE = \
 	python bin/compile.py \
 	-d $$(date "+%Y-%m-%d") \
 	-o $(OUT_DIR) \
-	-p . -p bootcamps -p 3_0 -p 4_0 -p blog \
+	-p . -p bootcamps -p people -p 3_0 -p 4_0 -p blog \
 	-s $(SITE) \
 	-v
 

--- a/about/team.html
+++ b/about/team.html
@@ -16,616 +16,69 @@
 
 <h2 id="advisory">Advisory Board</h2>
 
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/brown-titus.jpg" alt="C. Titus Brown" />
-  <div id="brown.ct"
-  class="media-body"><span class="person"><a href="http://ivory.idyll.org/blog/">C. Titus
-  Brown</a></span> is an assistant professor at Michigan State University in
-  the CSE and Microbiology departments, where he works
-  on <a href="http://ged.msu.edu/">data-driven biology</a></div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/cholia-shreyas.jpg" alt="Shreyas Cholia" />
-  <div id="cholia.s"
-  class="media-body"><a href="http://www.nersc.gov/about/nersc-staff/outreach-software-and-programming-group/shreyas-cholia/"><span class="person">Shreyas
-  Cholia</span></a> works on science gateway, web and grid technologies for
-  the National Energy Research Scientific Computing Center (NERSC) at Lawrence
-  Berkeley National Laboratory, where he works to make high-performance
-  scientific computing more transparent and accessible. He went to Rice
-  University where he studied Computer Science and Cognitive Sciences.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/goble-carole.jpg" alt="Carole Goble" />
-  <div id="goble.c"
-  class="media-body"><a href="http://www.cs.man.ac.uk/~carole/"><span class="person">Carole
-  Goble</span></a> is Professor of Computer Science in the University of
-  Manchester, and has spent the past twenty years developing innovative
-  computing approaches in knowledge management, distributed computing and
-  social computing to support scientific researchers in a wide variety of
-  areas, including Taverna, BioCatalogue, myExperiment, and SEEK.  She is a
-  partner in the UK's Software Sustainability Institute.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/petre-marian.jpg" alt="Marian Petre" />
-  <div id="petre.m"
-  class="media-body"><a href="http://mcs.open.ac.uk/mp8/"><span class="person">Marian
-  Petre</span></a> is a Professor of Computing at the Open University. She
-  holds a Royal Society/Wolfson Research Merit Award in recognition of her
-  research on expertise in software design. With degrees in both
-  Psycholinguistics and Computer Science, Marian's research spans empirical
-  studies of software development, representation and visualisation for
-  software design, psychology of programming, human-centred computing, and
-  computer science education.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/plumbley-mark.jpg" alt="Mark Plumbley" />
-  <div id="plumbley.m"
-  class="media-body"><a href="http://www.elec.qmul.ac.uk/people/markp/"><span class="person">Mark
-  Plumbley</span></a> is Director of the Centre for Digital Music (C4DM) at
-  Queen Mary, University of London, and leads
-  the <a href="http://soundsoftware.ac.uk/">SoundSoftware.ac.uk</a>
-  project. His work in audio signal analysis includes beat tracking, music
-  transcription, source separation and object coding, using techniques such as
-  neural networks, independent component analysis, sparse representations and
-  Bayesian modeling.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/white-ethan.jpg" alt="Ethan White" />
-  <div id="white.e"
-  class="media-body"><a href="http://ethanwhite.org"><span class="person">Ethan
-  White</span></a> is an Associate Professor in the Department of Biology and
-  the Ecology Center at Utah State University. He is a recipient of the
-  prestigious National Science Foundation CAREER "Young Investigators"
-  Award. He is a proponent of open and reproducible science and serves on the
-  editorial boards of both PLOS ONE and PeerJ.</div>
-</div>
+{% include "brown.ct.html" %}
+{% include "cholia.s.html" %}
+{% include "goble.c.html" %}
+{% include "petre.m.html" %}
+{% include "plumbley.m.html" %}
+{% include "white.e.html" %}
 
 <h2 id="instructors">Instructors</h2>
 
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/anderson-carlos.jpg" alt="Carlos Anderson" />
-  <div id="anderson.c"
-  class="media-body"><a href="http://www.msu.edu/~carlosja"><span class="person">Carlos
-  Anderson</span></a> is a Ph.D. candidate in Evolutionary Biology at Michigan
-  State University, where he is studying the genetic mechanisms of speciation
-  using artificial life. He obtained his B.S. in Computer Science and M.S. in
-  Biology at the University of Central Florida.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/aruliah-dhavide.jpg" alt="Dhavide Aruliah" />
-  <div id="aruliah.d"
-  class="media-body"><span class="person"><a href="http://faculty.uoit.ca/aruliah/">Dhavide
-  Aruliah</a></span> is an associate professor at the University of Ontario
-  Institute of Technology in Oshawa, Ontario. His research interests are in
-  scientific computing, specifically in computational inverse problems,
-  numerical linear algebra, and the numerical solution of PDEs.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/bostroem-azalee.jpg" alt="Azalee Bostroem" />
-  <div id="bostroem.a" class="media-body"><span class="person">Azalee
-  Bostroem</span> is a Senior Research and Instrument Analyst at the Space
-  Telescope Science Institute.  She is primarily responsible for organizing
-  the development of the calibration pipelines of the two spectrographs on the
-  Hubble Space Telescope (the <a href="http://www.stsci.edu/hst/cos/">Cosmic
-  Origins Spectrograph</a> and <a href="http://www.stsci.edu/hst/stis/">Space
-  Telescope Imaging Spectrograph</a>) to meet the scientific needs of the
-  astronomical community. She also collaborates on a project using the Space
-  Telescope Imaging Spectrograph to derive the properties of massive
-  stars.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/bray-erik.jpg" alt="Erik Bray" />
-  <div id="bray.e" class="media-body"><span class="person">Erik Bray</span> is
-  a software engineer in the science software branch at Space Telescope
-  Science Institute, where he works primarily on supporting Hubble and JWST
-  science software.  His software experience ranges from web development to
-  kernel hacking, and in his "free" time he's working on an MS in Applied
-  Physics.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/canino-koning-rosangela.jpg" alt="Rosangela Canino-Koning" />
-  <div id="canino-koning.r" class="media-body"> After 13 years of slogging in
-  the software industry
-  trenches, <a href="http://www.voidptr.net/"><span class="person">Rosangela
-  Canino-Koning</span></a> returned to university to pursue a PhD in Computer
-  Science and Evolutionary Biology at Michigan State University. In her
-  copious spare time, she reads, hikes, travels, and hacks on open source
-  software.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/cannam-chris.png" alt="Chris Cannam" />
-  <div id="cannam.c" class="media-body"><span class="person">Chris
-  Cannam</span> is a software developer with the Sound Software project at
-  Queen Mary, University of London. He has had extensive experience as a
-  commercial software developer and on numerous open source applications,
-  particularly in the music and audio fields.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/howe-adina.jpg" alt="Adina Chuang Howe" />
-  <div id="chuang-howe.a" class="media-body"><span class="person">Adina Chuang
-  Howe</span> received her PhD in Environmental Engineering. She is currently
-  a postdoctoral research scientist at Michigan State University, where she
-  uses skills learned from Software Carpentry to study microbial communities
-  in the environment.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/chue-hong-neil.jpg" alt="Neil Chue Hong" />
-  <div id="chue-hong.n"
-  class="media-body"><a href="http://www.epcc.ed.ac.uk/about-us/staff/chue-hong-neil/"><span class="person">Neil
-  Chue Hong</span></a> is Director of
-  the <a href="http://www.software.ac.uk/">Software Sustainability
-  Institute</a>, and is based at the University of Edinburgh. His research
-  interests are in community engagement and development, software
-  sustainability, and the integration and analysis of data.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/crouch-steve.jpg" alt="Steve Crouch" />
-  <div id="crouch.s"
-  class="media-body"><a href="http://users.ecs.soton.ac.uk/stc/"><span class="person">Steve
-  Crouch</span></a> is a software architect at
-  the <a href="http://www.software.ac.uk">Software Sustainability
-  Institute</a>, and is based at
-  the <a href="http://www.soton.ac.uk">University of Southampton</a>. He
-  assists researchers and their communities by consulting on software that is
-  integral to their research.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/davis-matt.jpg" alt="Matt Davis" />
-  <div id="davis.m"
-  class="media-body"><span class="person"><a href="http://penandpants.com/">Matt
-  Davis</a></span> is a software developer at the Space Telescope Science
-  Institute where he works on Python and C projects that support Hubble
-  science. He also spends a bit of time spreading Python around the office. He
-  previously worked at NASA's Goddard Space Flight Center where he wrote
-  Python software to support atmospheric science research.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/dickson-ross.png" alt="Ross Dickson" />
-  <div id="dickson.r" class="media-body"><span class="person">Ross
-  Dickson</span> has a Ph.D. in computational chemistry, and has been back and
-  forth between academia and the software development industry a few times
-  over the years. Now he helps profs, post-docs, and students in Atlantic
-  Canada solve research problems involving high-performance computers.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/dursi-jonathan.jpg" alt="Jonathan Dursi" />
-  <div id="dursi.j"
-  class="media-body"><a href="http://www.cita.utoronto.ca/~ljdursi/"><span class="person">Jonathan
-  Dursi</span></a> is an astrophysicist with twenty years' experience in
-  computational science. He has taught courses in computing from the desktop
-  to supercomputers in Canada, the US, and South Africa. In 2000, as part of
-  the US DoE ASC Flash team, he won a Gordon Bell Award, one of
-  supercomputing's highest accolades.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/ely-justin.jpg" alt="Justin Ely" />
-  <div id="ely.j" class="media-body"><span class="person">Justin Ely</span> is
-  a Research and Instrument Analyst at the Space Telescope Science Institute
-  where he supports the science operations of the Hubble Space
-  Telescope. Primarily, he uses Python to monitor and improve the performance
-  of the two on-board spectrographs, the Cosmic Origins Spectrograph and the
-  Space Telescope Imaging Spectrograph.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/gustavsen-julia.jpg" alt="Julia Gustavsen" />
-  <div id="gustavsen.j" class="media-body"><span class="person">Julia
-  Gustavsen</span> is a PhD student at the University of British Columbia in
-  Biological Oceanography.  Her thesis work focuses on the changes that take
-  place in marine viral communities over time and space. She received her BA
-  and BSc from the University of New Brunswick.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/guy-tommy.jpg" alt="Richard 'Tommy' Guy" />
-  <div id="guy.t"
-  class="media-body"><a href="http://www.cs.toronto.edu/~guy/"><span class="person">Richard
-  "Tommy" Guy</span></a> is a PhD student in Computer Science at the
-  University of Toronto. While at <a href="http://www.wfu.edu/">Wake Forest
-  University</a>, he helped
-  create <a href="https://sites.google.com/site/verbalvictor/">Verbal
-  Victor</a>, an app to help children with communication difficulties.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/haddock-steven.jpg" alt="Steven Haddock" />
-  <div id="haddock.s"
-  class="media-body"><a href="http://www.mbari.org/staff/haddock/"><span class="person">Steven
-  Haddock</span></a> is a Research Scientist at the Monterey Bay Aquarium
-  Research Institute and adjunct Associate Professor at U.C. Santa Cruz,
-  studying bioluminescence and biodiversity of marine zooplankton. He
-  co-authored <a href="http://practicalcomputing.org/"><cite>Practical
-  Computing for Biologists</cite></a> with Casey Dunn.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/hansen-michael.jpg" alt="Mike Hansen" />
-  <div id="hansen.m" class="media-body"><span class="person">Mike
-  Hansen</span> is a PhD student in Computer Science and Cognitive Science at
-  Indiana University. His research interests include quantifying the
-  complexity of software using cognitive models of programmers. He has
-  designed and developed software professionally for almost ten years, and
-  enjoys teaching others the skill and art of programming.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/hart-ted.jpg" alt="Ted Hart" />
-  <div id="hart.t" class="media-body"><span class="person">Ted Hart</span> is
-  a post-doc at the University of British Columbia where he studies the
-  evolution of sociality in spiders using individual based models and
-  evolutionary algorithms.  He received his PhD from the University of Vermont
-  and is a member of the rOpenSci development group.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/hinsen-konrad.jpg" alt="Konrad Hinsen" />
-  <div id="hinsen.k"
-  class="media-body"><a href="http://dirac.cnrs-orleans.fr/"><span class="person">Konrad
-  Hinsen</span></a> is a theoretical physicist by training who currently works
-  on protein structure and dynamics and scientific computing at the Centre de
-  Biophysique Mol&eacute;culaire in Orl&eacute;ans (France) and at the
-  Synchrotron Soleil in Saint Aubin (France). He is also a department editor
-  for <cite>Computing in Science and Engineering</cite>.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/huff-katy.png" alt="Katy Huff" />
-  <div id="huff.k"
-  class="media-body"><a href="http://homepages.cae.wisc.edu/~khuff/"><span class="person">Katy
-  Huff</span></a> is a PhD student in nuclear engineering at the University of
-  Wisconsin &ndash; Madison, where she helped
-  found <a href="https://github.com/thehackerwithin">The Hacker
-  Within</a>.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/jackson-mike.jpg" alt="Mike Jackson" />
-  <div id="jackson.m" class="media-body"><span class="person">Mike
-  Jackson</span> has a background in human-computer interaction and is a
-  software architect at the <a href="http://www.epcc.ed.ac.uk">Edinburgh
-  Parallel Computing Centre</a>. He is also a consultant with
-  the <a href="http://software.ac.uk">Software Sustainability
-  Institute</a>.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/kerr-jessica.jpg" alt="Jessica Kerr" />
-  <div id="kerr.j" class="media-body"><span class="person">Jessica Kerr</span>
-  has channeled an undergraduate physics degree into a programming career. She
-  loves computer science, especially when it intersects with math and
-  complexity theory. Her goals include acquiring new tastes, sharing
-  enthusiasm, and keeping two crazy-happy children alive.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/king-trevor.jpg" alt="Trevor King" />
-  <div id="king.w"
-  class="media-body"><span class="person"><a href="http://blog.tremily.us/">W. Trevor
-  King</a></span> is a PhD student in Physics at Drexel University. He studies
-  single-molecule protein unfolding, focusing on open source experiment
-  control and automation using <a href="http://comedi.org/">Comedi</a> and
-  Python. This has led to exposure to a wide range of software, and he
-  moonlights as an evangelist for open source software in general, and Git and
-  Python in particular.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/kitzes-justin.jpg" alt="Justin Kitzes" />
-  <div id="kitzes.j" class="media-body"><span class="person">Justin
-  Kitzes</span> is a postdoc in the Energy and Resources Group at the
-  University of California, Berkeley. His research centers on the intersection
-  of quantitative ecology and conservation biology, with a focus on developing
-  general methods to predict spatial patterns of biodiversity in human-altered
-  landscapes.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/konrad-bernhard.jpg" alt="Bernhard Konrad" />
-  <div id="konrad.b" class="media-body"><span class="person">Bernhard
-  Konrad</span> is a PhD student in Mathematical Biology at the University of
-  British Columbia. He studies early within-host events after HIV exposure and
-  how treatment or a vaccine could prevent infection. He received his Masters
-  at the Karlsruhe Institute of Technology in Germany, where he focused on
-  functional analysis.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/lagesen-karin.jpg" alt="Karin Lagesen" />
-  <div id="lagesen.k" class="media-body"><span class="person">Karin
-  Lagesen</span> has a PhD in bioinformatics and has since focused on the
-  processing of high throughput sequencing data in various forms. With a
-  background in both computational science and molecular biology, she has
-  taught programming and computational analysis to both master and PhD
-  students and believes that this should be an integral part of any
-  biologist's toolbox.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/langmore-ian.jpg" alt="Ian Langmore" />
-  <div id="langmore.i"
-  class="media-body"><span class="person"><a href="http://www.ianlangmore.com/">Ian
-  Langmore</a></span> is a mathematician/engineer working as a data scientist
-  in New York City.  He currently works at Johnson Research Labs and teaches
-  an Applied Data Science class in the Department of Statistics at Columbia
-  University.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/lasher-chris.png" alt="Chris Lasher" />
-  <div id="lasher.c" class="media-body"><span class="person">Chris
-  Lasher</span> works at the interfaces of molecular biology, computer
-  science, and software development. In 2007, he lead a weekly Software
-  Carpentry boot camp at Virginia Tech for postdocs and graduate students. To
-  this day, Chris continues to improve his good programming habits and extol
-  the virtues of Python, his most beloved programming language.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/latornell-doug.jpg" alt="Doug Latornell" />
-  <div id="latornell.d"
-  class="media-body"><span class="person"><a href="http://douglatornell.ca/">Doug
-  Latornell</a></span> is a professional engineer with a background of
-  creating and using software to solve problems in a wide range of application
-  areas. His post-graduate research was in the fields of experimental and
-  computational fluid mechanics (M.Sc.), and modeling and control of robotic
-  manipulators (Ph.D.).  By day he works for Nordion in Vancouver, where he
-  helps to produce a variety of medical isotopes by proton irradiation from
-  cyclotron accelerators.  Side projects include software engineering support
-  for a coupled biology and physics model of deep estuaries, and an
-  operational deployment of that model that, through the winter months,
-  calculates a daily prediction of the date of the first spring phytoplankton
-  bloom in the Strait of Georgia.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/mcgough-stephen.jpg" alt="Stephen McGough" />
-  <div id="mcgough.s"
-  class="media-body"><span class="person"><a href="http://www.ncl.ac.uk/computing/people/profile/Stephen.McGough">Stephen
-  McGough</a></span> is the Research Manager for
-  the <a href="http://digitalinstitute.ncl.ac.uk">Digital Institute</a>
-  at <a href="http://www.ncl.ac.uk">Newcastle University</a>. His research
-  interests lie in the areas of high performance and high throughput computing
-  along with their implications for green computing.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/mckellar-jessica.jpg" alt="Jessica McKellar" />
-  <div id="mckellar.j"
-  class="media-body"><span class="person"><a href="http://jesstess.com/">Jessica
-  McKellar</a></span> is a kernel engineer living in Cambridge, MA. She is a
-  Python Software Foundation board member and an organizer for the largest
-  Python user group in the world. With that group she runs the Boston Python
-  Workshops for women and their friends&mdash;an introductory programming
-  pipeline that has brought hundreds of women into the local Python community
-  and is being replicated in cities across the US.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/mctavish-ej.jpg" alt="Emily Jane McTavish" />
-  <div id="mckellar.j"
-  class="media-body"><span class="person"><a href="https://sites.google.com/site/emilyjanemctavish/">Emily
-  Jane McTavish</a></span> is a PhD student at the University of Texas
-  studying the complex evolutionary history of Texas Longhorn cattle using
-  genomic data. In May 2013 she is starting a postdoc at University of Kansas
-  developing tools for updating and revising the tree of life, as part of
-  the <a href="http://opentreeoflife.org/">Open Tree</a> project.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/mitchell-ian.jpg" alt="Ian M. Mitchell" />
-  <div id="mitchell.i"
-  class="media-body"><span class="person"><a href="http://www.cs.ubc.ca/~mitchell/">Ian
-  M. Mitchell</a></span> is an associate professor in the Department of
-  Computer Science at the University of British Columbia. His research
-  interests include scientific computing, cyber-physical systems, formal
-  verification, and reproducible research.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/montojo-jason.png" alt="Jason Montojo" />
-  <div id="montojo.jason"
-  class="media-body"><span class="person"><a href="http://jason.montojo.com/blog/">Jason
-  Montojo</a></span> received his Master's degree in Computer Science from the
-  University of Toronto in 2009.  He currently works for
-  the <a href="http://pages.genemania.org/">GeneMANIA</a> team.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/nederbragt-lex.jpg" alt="Lex Nederbragt" />
-  <div id="nederbragt.lex"
-  class="media-body"><span class="person"><a href="http://flavors.me/flxlex">Lex
-  Nederbragt</a></span> is a self-taught bioinformatician working with
-  high-throughput DNA sequencing data at Oslo University, Norway. His
-  speciality is the assembly of genomes from short pieces of sequence
-  information.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/pell-jason.jpg" alt="Jason Pell" />
-  <div id="pell.j"
-  class="media-body"><a href="http://www.cse.msu.edu/~pelljaso"><span class="person">Jason
-  Pell</span></a> is a Ph.D. student in Computer Science and Quantitative
-  Biology at Michigan State University who is primarily interested in tackling
-  large next-generation DNA sequencing datasets. He holds a B.A. in Computer
-  Science from Grand Valley State University.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/perez-fernando.jpg" alt="Fernando Perez" />
-  <div id="perez.f"
-  class="media-body"><a href="http://fperez.org/"><span class="person">Fernando
-  Perez</span></a> is a research scientist at the Helen Wills Neuroscience
-  Institute at U.C. Berkeley. His work involves the development and
-  implementation of new algorithms and tools for neuroimaging, with a special
-  interest in functional MRI. He is also actively involved with the
-  development of new tools for high-level scientific computing, mostly using
-  the Python language.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/rokem-ariel.jpg" alt="Ariel Rokem" />
-  <div id="rokem.a"
-  class="media-body"><span class="person"><a href="http://arokem.org">Ariel
-  Rokem</a></span> is a post-doctoral researcher at the Stanford Psychology
-  Department. His research focuses on the functional neuroanatomy of the human
-  visual system. Since his time as a PhD student at UC Berkeley, he has been
-  involved in developing open source software for neuroimaging.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/scopatz-anthony.png" alt="Anthony Scopatz" />
-  <div id="scopatz.a"
-  class="media-body"><a href="http://scopatz.com/"><span class="person">Anthony
-  Scopatz</span></a> has a PhD in Mechanical and Nuclear Engineering from the
-  University of Texas at Austin, and is now a post-doc in the Astrophysics
-  Department's FLASH Center at the University of Chicago.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/shelton-jeff.jpg" alt="Jeff Shelton" />
-  <div id="shelton.j"
-  class="media-body"><a href="http://engineeringrevision.com/about/"><span class="person">Jeff
-  Shelton</span></a> is a PhD candidate in Mechanical Engineering at Purdue
-  University, studying the control aspects of human motion. Following more
-  than two decades in industry, he is interested in aligning educational
-  methods with the evolving societal roles performed by engineers.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/smith-joshua.jpg" alt="Joshua Ryan Smith" />
-  <div id="smith.j" class="media-body"><span class="person">Joshua Ryan
-  Smith</span> specializes in electronic devices based on wide-bandgap
-  semiconductor materials and in the past has done work in surface science and
-  nanofabrication. Joshua is a native of North Carolina and received his
-  Ph.D. in physics from North Carolina State University; he learned Python
-  programming in graduate school and has an interest in understanding the
-  design of experiments in terms of the practices of software
-  development.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/supp-sarah.jpg" alt="Sarah Supp" />
-  <div id="supp.s" class="media-body"><span class="person">Sarah Supp</span>
-  is a Ph.D. student in Biology and Ecology at Utah State University. Her
-  research interests lie in combining field studies, macroecological analyses
-  and ecoinformatics to understand the dynamics that drive change at the
-  community and ecosystem level. She uses R, Python, MySQL, and version
-  control to handle the large datasets needed to explore ecological questions
-  focused at large spatiotemporal scales.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/varoquaux-nelle.jpg" alt="Nelle Varoquaux" />
-  <div id="varoquaux.n" class="media-body">After working as a Python software
-  engineer, <span class="person">Nelle Varoquaux</span> returned to university
-  in 2011 to pursue an applied mathematics degree, specializing in machine
-  learning. She is now interested in using these newly acquired skills to
-  solve biological problems, such as reconstructing the 3D architecture of the
-  genome.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/viana-alex.jpg" alt="Alex Viana" />
-  <div id="viana.a" class="media-body"><span class="person">Alex Viana</span>
-  is a Research and Instrument Analyst at the <a href="http://stsci.edu">Space
-  Telescope Science Institute</a> where he supports the operations of the
-  Hubble Space Telescope. Primarily working in Python and SQL he has
-  contributed to a wide range of scientific and educational projects at
-  STScI.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/waugh-ben.jpg" alt="Ben Waugh" />
-  <div id="waugh.b"
-  class="media-body"><a href="http://www.hep.ucl.ac.uk/~waugh/"><span class="person">Ben
-  Waugh</span></a> writes and maintains software, teaches programming and a
-  bit of physics, manages computer systems and drinks lots of coffee in
-  the <a href="http://www.phys.ucl.ac.uk/">Department of Physics and
-  Astronomy</a> at <a href="http://www.ucl.ac.uk/">University College
-  London</a>, mostly in the <a href="http://www.hep.ucl.ac.uk/">High-Energy
-  Physics Group</a>.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/williams-lynne.jpg" alt="Lynne Williams" />
-  <div id="williams.l"
-  class="media-body"><a href="http://research.baycrest.org/lwilliams"><span class="person">Lynne
-  Williams</span></a> works at the Rotman-Baycrest Research Institute, where
-  she studies the cognitive neuroscience of language development over the
-  lifespan and develops statistical techniques to analyze large multivariate
-  data sets.  Her most recent work is concerned with pattern classifiers in
-  brain imaging and age-associated patterns of variability in brain
-  activation.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/wilson-greg.jpg" alt="Greg Wilson" />
-  <div id="wilson.g"
-  class="media-body"><a href="http://www.third-bit.com"><span class="person">Greg
-  Wilson</span></a> started the Software Carpentry project in 1998. He has
-  been a professional software developer, an author, and a university
-  professor. Greg received his PhD in Computer Science from the University of
-  Edinburgh in 1993.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/wilson-paul.jpg" alt="Paul Wilson" />
-  <div id="wilson.p"
-  class="media-body"><a href="http://cnerg.github.com/"><span class="person">Paul
-  Wilson</span></a> is an Associate Professor at the U. Wisconsin-Madison
-  where he teaches nuclear engineering.  His research
-  group, <a href="http://cnerg.github.com">CNERG</a>, delivers new capability
-  for the simulation of nuclear systems.  The Hacker Within was born from his
-  research group as he tried to impart Software Carpentry skills upon his
-  graduate students. </div>
-</div>
+{% include "anderson.c.html" %}
+{% include "aruliah.d.html" %}
+{% include "bostroem.a.html" %}
+{% include "bray.e.html" %}
+{% include "canino-koning.r.html" %}
+{% include "cannam.c.html" %}
+{% include "chuang-howe.a.html" %}
+{% include "chue-hong.n.html" %}
+{% include "crouch.s.html" %}
+{% include "davis.m.html" %}
+{% include "dickson.r.html" %}
+{% include "dursi.j.html" %}
+{% include "ely.j.html" %}
+{% include "gustavsen.j.html" %}
+{% include "guy.t.html" %}
+{% include "haddock.s.html" %}
+{% include "hansen.m.html" %}
+{% include "hart.t.html" %}
+{% include "hinsen.k.html" %}
+{% include "huff.k.html" %}
+{% include "jackson.m.html" %}
+{% include "kerr.j.html" %}
+{% include "king.w.html" %}
+{% include "kitzes.j.html" %}
+{% include "konrad.b.html" %}
+{% include "lagesen.k.html" %}
+{% include "langmore.i.html" %}
+{% include "lasher.c.html" %}
+{% include "latornell.d.html" %}
+{% include "mcgough.s.html" %}
+{% include "mckellar.j.html" %}
+{% include "mckellar.j.html" %}
+{% include "mitchell.i.html" %}
+{% include "montojo.jason.html" %}
+{% include "nederbragt.lex.html" %}
+{% include "pell.j.html" %}
+{% include "perez.f.html" %}
+{% include "pickens.c.html" %}
+{% include "rokem.a.html" %}
+{% include "scopatz.a.html" %}
+{% include "shelton.j.html" %}
+{% include "smith.j.html" %}
+{% include "supp.s.html" %}
+{% include "varoquaux.n.html" %}
+{% include "viana.a.html" %}
+{% include "waugh.b.html" %}
+{% include "williams.l.html" %}
+{% include "wilson.g.html" %}
+{% include "wilson.p.html" %}
 
 <h2 id="support">Support</h2>
 
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/aranda-jorge.jpg" alt="Jorge Aranda" />
-  <div id="aranda.j"
-  class="media-body"><a href="http://catenary.wordpress.com/about/"><span class="person">Jorge
-  Aranda</span></a> obtained his Ph.D. in Computer Science at the University
-  of Toronto. He is now a postdoctoral researcher at the University of
-  Victoria, where he studies coordination and communication in software
-  teams.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/pickens-caitlyn.jpg" alt="Caitlyn Pickens" />
-  <div id="pickens.c"
-  class="media-body"><a href="http://michigancomputes.wordpress.com/"><span class="person">Caitlyn
-  Pickens</span></a> is a graduate student at Michigan State University. She
-  researches education techniques in the undergraduate computer science
-  classroom&mdash;specifically, the flipped classroom and active
-  learning.</div>
-</div>
-
-<div class="media">
-  <img class="media-object pull-left" src="{{root_path}}/img/people/pipitone-jon.jpg" alt="Jon Pipitone" />
-  <div id="pipitone.j" class="media-body"><span class="person">Jon
-  Pipitone</span> completed his MSc in Computer Science at the University of
-  Toronto in 2010. He has been active since then in a variety of scientific,
-  environmental, and social justice causes.</div>
-</div>
+{% include "aranda.j.html" %}
+{% include "pipitone.j.html" %}
 
 {% endblock content %}
 

--- a/people/anderson.c.html
+++ b/people/anderson.c.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/anderson-carlos.jpg" alt="Carlos Anderson" />
+  <div id="anderson.c"
+  class="media-body"><a href="http://www.msu.edu/~carlosja"><span class="person">Carlos
+  Anderson</span></a> is a Ph.D. candidate in Evolutionary Biology at Michigan
+  State University, where he is studying the genetic mechanisms of speciation
+  using artificial life. He obtained his B.S. in Computer Science and M.S. in
+  Biology at the University of Central Florida.</div>
+</div>

--- a/people/aranda.j.html
+++ b/people/aranda.j.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/aranda-jorge.jpg" alt="Jorge Aranda" />
+  <div id="aranda.j"
+  class="media-body"><a href="http://catenary.wordpress.com/about/"><span class="person">Jorge
+  Aranda</span></a> obtained his Ph.D. in Computer Science at the University
+  of Toronto. He is now a postdoctoral researcher at the University of
+  Victoria, where he studies coordination and communication in software
+  teams.</div>
+</div>

--- a/people/aruliah.d.html
+++ b/people/aruliah.d.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/aruliah-dhavide.jpg" alt="Dhavide Aruliah" />
+  <div id="aruliah.d"
+  class="media-body"><span class="person"><a href="http://faculty.uoit.ca/aruliah/">Dhavide
+  Aruliah</a></span> is an associate professor at the University of Ontario
+  Institute of Technology in Oshawa, Ontario. His research interests are in
+  scientific computing, specifically in computational inverse problems,
+  numerical linear algebra, and the numerical solution of PDEs.</div>
+</div>

--- a/people/bostroem.a.html
+++ b/people/bostroem.a.html
@@ -1,0 +1,13 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/bostroem-azalee.jpg" alt="Azalee Bostroem" />
+  <div id="bostroem.a" class="media-body"><span class="person">Azalee
+  Bostroem</span> is a Senior Research and Instrument Analyst at the Space
+  Telescope Science Institute.  She is primarily responsible for organizing
+  the development of the calibration pipelines of the two spectrographs on the
+  Hubble Space Telescope (the <a href="http://www.stsci.edu/hst/cos/">Cosmic
+  Origins Spectrograph</a> and <a href="http://www.stsci.edu/hst/stis/">Space
+  Telescope Imaging Spectrograph</a>) to meet the scientific needs of the
+  astronomical community. She also collaborates on a project using the Space
+  Telescope Imaging Spectrograph to derive the properties of massive
+  stars.</div>
+</div>

--- a/people/bray.e.html
+++ b/people/bray.e.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/bray-erik.jpg" alt="Erik Bray" />
+  <div id="bray.e" class="media-body"><span class="person">Erik Bray</span> is
+  a software engineer in the science software branch at Space Telescope
+  Science Institute, where he works primarily on supporting Hubble and JWST
+  science software.  His software experience ranges from web development to
+  kernel hacking, and in his "free" time he's working on an MS in Applied
+  Physics.</div>
+</div>

--- a/people/brown.ct.html
+++ b/people/brown.ct.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/brown-titus.jpg" alt="C. Titus Brown" />
+  <div id="brown.ct"
+  class="media-body"><span class="person"><a href="http://ivory.idyll.org/blog/">C. Titus
+  Brown</a></span> is an assistant professor at Michigan State University in
+  the CSE and Microbiology departments, where he works
+  on <a href="http://ged.msu.edu/">data-driven biology</a></div>
+</div>

--- a/people/canino-koning.r.html
+++ b/people/canino-koning.r.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/canino-koning-rosangela.jpg" alt="Rosangela Canino-Koning" />
+  <div id="canino-koning.r" class="media-body"> After 13 years of slogging in
+  the software industry
+  trenches, <a href="http://www.voidptr.net/"><span class="person">Rosangela
+  Canino-Koning</span></a> returned to university to pursue a PhD in Computer
+  Science and Evolutionary Biology at Michigan State University. In her
+  copious spare time, she reads, hikes, travels, and hacks on open source
+  software.</div>
+</div>

--- a/people/cannam.c.html
+++ b/people/cannam.c.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/cannam-chris.png" alt="Chris Cannam" />
+  <div id="cannam.c" class="media-body"><span class="person">Chris
+  Cannam</span> is a software developer with the Sound Software project at
+  Queen Mary, University of London. He has had extensive experience as a
+  commercial software developer and on numerous open source applications,
+  particularly in the music and audio fields.</div>
+</div>

--- a/people/cholia.s.html
+++ b/people/cholia.s.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/cholia-shreyas.jpg" alt="Shreyas Cholia" />
+  <div id="cholia.s"
+  class="media-body"><a href="http://www.nersc.gov/about/nersc-staff/outreach-software-and-programming-group/shreyas-cholia/"><span class="person">Shreyas
+  Cholia</span></a> works on science gateway, web and grid technologies for
+  the National Energy Research Scientific Computing Center (NERSC) at Lawrence
+  Berkeley National Laboratory, where he works to make high-performance
+  scientific computing more transparent and accessible. He went to Rice
+  University where he studied Computer Science and Cognitive Sciences.</div>
+</div>

--- a/people/chuang-howe.a.html
+++ b/people/chuang-howe.a.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/howe-adina.jpg" alt="Adina Chuang Howe" />
+  <div id="chuang-howe.a" class="media-body"><span class="person">Adina Chuang
+  Howe</span> received her PhD in Environmental Engineering. She is currently
+  a postdoctoral research scientist at Michigan State University, where she
+  uses skills learned from Software Carpentry to study microbial communities
+  in the environment.</div>
+</div>

--- a/people/chue-hong.n.html
+++ b/people/chue-hong.n.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/chue-hong-neil.jpg" alt="Neil Chue Hong" />
+  <div id="chue-hong.n"
+  class="media-body"><a href="http://www.epcc.ed.ac.uk/about-us/staff/chue-hong-neil/"><span class="person">Neil
+  Chue Hong</span></a> is Director of
+  the <a href="http://www.software.ac.uk/">Software Sustainability
+  Institute</a>, and is based at the University of Edinburgh. His research
+  interests are in community engagement and development, software
+  sustainability, and the integration and analysis of data.</div>
+</div>

--- a/people/crouch.s.html
+++ b/people/crouch.s.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/crouch-steve.jpg" alt="Steve Crouch" />
+  <div id="crouch.s"
+  class="media-body"><a href="http://users.ecs.soton.ac.uk/stc/"><span class="person">Steve
+  Crouch</span></a> is a software architect at
+  the <a href="http://www.software.ac.uk">Software Sustainability
+  Institute</a>, and is based at
+  the <a href="http://www.soton.ac.uk">University of Southampton</a>. He
+  assists researchers and their communities by consulting on software that is
+  integral to their research.</div>
+</div>

--- a/people/davis.m.html
+++ b/people/davis.m.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/davis-matt.jpg" alt="Matt Davis" />
+  <div id="davis.m"
+  class="media-body"><span class="person"><a href="http://penandpants.com/">Matt
+  Davis</a></span> is a software developer at the Space Telescope Science
+  Institute where he works on Python and C projects that support Hubble
+  science. He also spends a bit of time spreading Python around the office. He
+  previously worked at NASA's Goddard Space Flight Center where he wrote
+  Python software to support atmospheric science research.</div>
+</div>

--- a/people/dickson.r.html
+++ b/people/dickson.r.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/dickson-ross.png" alt="Ross Dickson" />
+  <div id="dickson.r" class="media-body"><span class="person">Ross
+  Dickson</span> has a Ph.D. in computational chemistry, and has been back and
+  forth between academia and the software development industry a few times
+  over the years. Now he helps profs, post-docs, and students in Atlantic
+  Canada solve research problems involving high-performance computers.</div>
+</div>

--- a/people/dursi.j.html
+++ b/people/dursi.j.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/dursi-jonathan.jpg" alt="Jonathan Dursi" />
+  <div id="dursi.j"
+  class="media-body"><a href="http://www.cita.utoronto.ca/~ljdursi/"><span class="person">Jonathan
+  Dursi</span></a> is an astrophysicist with twenty years' experience in
+  computational science. He has taught courses in computing from the desktop
+  to supercomputers in Canada, the US, and South Africa. In 2000, as part of
+  the US DoE ASC Flash team, he won a Gordon Bell Award, one of
+  supercomputing's highest accolades.</div>
+</div>

--- a/people/ely.j.html
+++ b/people/ely.j.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/ely-justin.jpg" alt="Justin Ely" />
+  <div id="ely.j" class="media-body"><span class="person">Justin Ely</span> is
+  a Research and Instrument Analyst at the Space Telescope Science Institute
+  where he supports the science operations of the Hubble Space
+  Telescope. Primarily, he uses Python to monitor and improve the performance
+  of the two on-board spectrographs, the Cosmic Origins Spectrograph and the
+  Space Telescope Imaging Spectrograph.</div>
+</div>

--- a/people/goble.c.html
+++ b/people/goble.c.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/goble-carole.jpg" alt="Carole Goble" />
+  <div id="goble.c"
+  class="media-body"><a href="http://www.cs.man.ac.uk/~carole/"><span class="person">Carole
+  Goble</span></a> is Professor of Computer Science in the University of
+  Manchester, and has spent the past twenty years developing innovative
+  computing approaches in knowledge management, distributed computing and
+  social computing to support scientific researchers in a wide variety of
+  areas, including Taverna, BioCatalogue, myExperiment, and SEEK.  She is a
+  partner in the UK's Software Sustainability Institute.</div>
+</div>

--- a/people/gustavsen.j.html
+++ b/people/gustavsen.j.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/gustavsen-julia.jpg" alt="Julia Gustavsen" />
+  <div id="gustavsen.j" class="media-body"><span class="person">Julia
+  Gustavsen</span> is a PhD student at the University of British Columbia in
+  Biological Oceanography.  Her thesis work focuses on the changes that take
+  place in marine viral communities over time and space. She received her BA
+  and BSc from the University of New Brunswick.</div>
+</div>

--- a/people/guy.t.html
+++ b/people/guy.t.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/guy-tommy.jpg" alt="Richard 'Tommy' Guy" />
+  <div id="guy.t"
+  class="media-body"><a href="http://www.cs.toronto.edu/~guy/"><span class="person">Richard
+  "Tommy" Guy</span></a> is a PhD student in Computer Science at the
+  University of Toronto. While at <a href="http://www.wfu.edu/">Wake Forest
+  University</a>, he helped
+  create <a href="https://sites.google.com/site/verbalvictor/">Verbal
+  Victor</a>, an app to help children with communication difficulties.</div>
+</div>

--- a/people/haddock.s.html
+++ b/people/haddock.s.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/haddock-steven.jpg" alt="Steven Haddock" />
+  <div id="haddock.s"
+  class="media-body"><a href="http://www.mbari.org/staff/haddock/"><span class="person">Steven
+  Haddock</span></a> is a Research Scientist at the Monterey Bay Aquarium
+  Research Institute and adjunct Associate Professor at U.C. Santa Cruz,
+  studying bioluminescence and biodiversity of marine zooplankton. He
+  co-authored <a href="http://practicalcomputing.org/"><cite>Practical
+  Computing for Biologists</cite></a> with Casey Dunn.</div>
+</div>

--- a/people/hansen.m.html
+++ b/people/hansen.m.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/hansen-michael.jpg" alt="Mike Hansen" />
+  <div id="hansen.m" class="media-body"><span class="person">Mike
+  Hansen</span> is a PhD student in Computer Science and Cognitive Science at
+  Indiana University. His research interests include quantifying the
+  complexity of software using cognitive models of programmers. He has
+  designed and developed software professionally for almost ten years, and
+  enjoys teaching others the skill and art of programming.</div>
+</div>

--- a/people/hart.t.html
+++ b/people/hart.t.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/hart-ted.jpg" alt="Ted Hart" />
+  <div id="hart.t" class="media-body"><span class="person">Ted Hart</span> is
+  a post-doc at the University of British Columbia where he studies the
+  evolution of sociality in spiders using individual based models and
+  evolutionary algorithms.  He received his PhD from the University of Vermont
+  and is a member of the rOpenSci development group.</div>
+</div>

--- a/people/hinsen.k.html
+++ b/people/hinsen.k.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/hinsen-konrad.jpg" alt="Konrad Hinsen" />
+  <div id="hinsen.k"
+  class="media-body"><a href="http://dirac.cnrs-orleans.fr/"><span class="person">Konrad
+  Hinsen</span></a> is a theoretical physicist by training who currently works
+  on protein structure and dynamics and scientific computing at the Centre de
+  Biophysique Mol&eacute;culaire in Orl&eacute;ans (France) and at the
+  Synchrotron Soleil in Saint Aubin (France). He is also a department editor
+  for <cite>Computing in Science and Engineering</cite>.</div>
+</div>

--- a/people/huff.k.html
+++ b/people/huff.k.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/huff-katy.png" alt="Katy Huff" />
+  <div id="huff.k"
+  class="media-body"><a href="http://homepages.cae.wisc.edu/~khuff/"><span class="person">Katy
+  Huff</span></a> is a PhD student in nuclear engineering at the University of
+  Wisconsin &ndash; Madison, where she helped
+  found <a href="https://github.com/thehackerwithin">The Hacker
+  Within</a>.</div>
+</div>

--- a/people/jackson.m.html
+++ b/people/jackson.m.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/jackson-mike.jpg" alt="Mike Jackson" />
+  <div id="jackson.m" class="media-body"><span class="person">Mike
+  Jackson</span> has a background in human-computer interaction and is a
+  software architect at the <a href="http://www.epcc.ed.ac.uk">Edinburgh
+  Parallel Computing Centre</a>. He is also a consultant with
+  the <a href="http://software.ac.uk">Software Sustainability
+  Institute</a>.</div>
+</div>

--- a/people/kerr.j.html
+++ b/people/kerr.j.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/kerr-jessica.jpg" alt="Jessica Kerr" />
+  <div id="kerr.j" class="media-body"><span class="person">Jessica Kerr</span>
+  has channeled an undergraduate physics degree into a programming career. She
+  loves computer science, especially when it intersects with math and
+  complexity theory. Her goals include acquiring new tastes, sharing
+  enthusiasm, and keeping two crazy-happy children alive.</div>
+</div>

--- a/people/king.w.html
+++ b/people/king.w.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/king-trevor.jpg" alt="Trevor King" />
+  <div id="king.w"
+  class="media-body"><span class="person"><a href="http://blog.tremily.us/">W. Trevor
+  King</a></span> is a PhD student in Physics at Drexel University. He studies
+  single-molecule protein unfolding, focusing on open source experiment
+  control and automation using <a href="http://comedi.org/">Comedi</a> and
+  Python. This has led to exposure to a wide range of software, and he
+  moonlights as an evangelist for open source software in general, and Git and
+  Python in particular.</div>
+</div>

--- a/people/kitzes.j.html
+++ b/people/kitzes.j.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/kitzes-justin.jpg" alt="Justin Kitzes" />
+  <div id="kitzes.j" class="media-body"><span class="person">Justin
+  Kitzes</span> is a postdoc in the Energy and Resources Group at the
+  University of California, Berkeley. His research centers on the intersection
+  of quantitative ecology and conservation biology, with a focus on developing
+  general methods to predict spatial patterns of biodiversity in human-altered
+  landscapes.</div>
+</div>

--- a/people/konrad.b.html
+++ b/people/konrad.b.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/konrad-bernhard.jpg" alt="Bernhard Konrad" />
+  <div id="konrad.b" class="media-body"><span class="person">Bernhard
+  Konrad</span> is a PhD student in Mathematical Biology at the University of
+  British Columbia. He studies early within-host events after HIV exposure and
+  how treatment or a vaccine could prevent infection. He received his Masters
+  at the Karlsruhe Institute of Technology in Germany, where he focused on
+  functional analysis.</div>
+</div>

--- a/people/lagesen.k.html
+++ b/people/lagesen.k.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/lagesen-karin.jpg" alt="Karin Lagesen" />
+  <div id="lagesen.k" class="media-body"><span class="person">Karin
+  Lagesen</span> has a PhD in bioinformatics and has since focused on the
+  processing of high throughput sequencing data in various forms. With a
+  background in both computational science and molecular biology, she has
+  taught programming and computational analysis to both master and PhD
+  students and believes that this should be an integral part of any
+  biologist's toolbox.</div>
+</div>

--- a/people/langmore.i.html
+++ b/people/langmore.i.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/langmore-ian.jpg" alt="Ian Langmore" />
+  <div id="langmore.i"
+  class="media-body"><span class="person"><a href="http://www.ianlangmore.com/">Ian
+  Langmore</a></span> is a mathematician/engineer working as a data scientist
+  in New York City.  He currently works at Johnson Research Labs and teaches
+  an Applied Data Science class in the Department of Statistics at Columbia
+  University.</div>
+</div>

--- a/people/lasher.c.html
+++ b/people/lasher.c.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/lasher-chris.png" alt="Chris Lasher" />
+  <div id="lasher.c" class="media-body"><span class="person">Chris
+  Lasher</span> works at the interfaces of molecular biology, computer
+  science, and software development. In 2007, he lead a weekly Software
+  Carpentry boot camp at Virginia Tech for postdocs and graduate students. To
+  this day, Chris continues to improve his good programming habits and extol
+  the virtues of Python, his most beloved programming language.</div>
+</div>

--- a/people/latornell.d.html
+++ b/people/latornell.d.html
@@ -1,0 +1,16 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/latornell-doug.jpg" alt="Doug Latornell" />
+  <div id="latornell.d"
+  class="media-body"><span class="person"><a href="http://douglatornell.ca/">Doug
+  Latornell</a></span> is a professional engineer with a background of
+  creating and using software to solve problems in a wide range of application
+  areas. His post-graduate research was in the fields of experimental and
+  computational fluid mechanics (M.Sc.), and modeling and control of robotic
+  manipulators (Ph.D.).  By day he works for Nordion in Vancouver, where he
+  helps to produce a variety of medical isotopes by proton irradiation from
+  cyclotron accelerators.  Side projects include software engineering support
+  for a coupled biology and physics model of deep estuaries, and an
+  operational deployment of that model that, through the winter months,
+  calculates a daily prediction of the date of the first spring phytoplankton
+  bloom in the Strait of Georgia.</div>
+</div>

--- a/people/mcgough.s.html
+++ b/people/mcgough.s.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/mcgough-stephen.jpg" alt="Stephen McGough" />
+  <div id="mcgough.s"
+  class="media-body"><span class="person"><a href="http://www.ncl.ac.uk/computing/people/profile/Stephen.McGough">Stephen
+  McGough</a></span> is the Research Manager for
+  the <a href="http://digitalinstitute.ncl.ac.uk">Digital Institute</a>
+  at <a href="http://www.ncl.ac.uk">Newcastle University</a>. His research
+  interests lie in the areas of high performance and high throughput computing
+  along with their implications for green computing.</div>
+</div>

--- a/people/mckellar.j.html
+++ b/people/mckellar.j.html
@@ -1,0 +1,21 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/mckellar-jessica.jpg" alt="Jessica McKellar" />
+  <div id="mckellar.j"
+  class="media-body"><span class="person"><a href="http://jesstess.com/">Jessica
+  McKellar</a></span> is a kernel engineer living in Cambridge, MA. She is a
+  Python Software Foundation board member and an organizer for the largest
+  Python user group in the world. With that group she runs the Boston Python
+  Workshops for women and their friends&mdash;an introductory programming
+  pipeline that has brought hundreds of women into the local Python community
+  and is being replicated in cities across the US.</div>
+</div>
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/mctavish-ej.jpg" alt="Emily Jane McTavish" />
+  <div id="mckellar.j"
+  class="media-body"><span class="person"><a href="https://sites.google.com/site/emilyjanemctavish/">Emily
+  Jane McTavish</a></span> is a PhD student at the University of Texas
+  studying the complex evolutionary history of Texas Longhorn cattle using
+  genomic data. In May 2013 she is starting a postdoc at University of Kansas
+  developing tools for updating and revising the tree of life, as part of
+  the <a href="http://opentreeoflife.org/">Open Tree</a> project.</div>
+</div>

--- a/people/mitchell.i.html
+++ b/people/mitchell.i.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/mitchell-ian.jpg" alt="Ian M. Mitchell" />
+  <div id="mitchell.i"
+  class="media-body"><span class="person"><a href="http://www.cs.ubc.ca/~mitchell/">Ian
+  M. Mitchell</a></span> is an associate professor in the Department of
+  Computer Science at the University of British Columbia. His research
+  interests include scientific computing, cyber-physical systems, formal
+  verification, and reproducible research.</div>
+</div>

--- a/people/montojo.jason.html
+++ b/people/montojo.jason.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/montojo-jason.png" alt="Jason Montojo" />
+  <div id="montojo.jason"
+  class="media-body"><span class="person"><a href="http://jason.montojo.com/blog/">Jason
+  Montojo</a></span> received his Master's degree in Computer Science from the
+  University of Toronto in 2009.  He currently works for
+  the <a href="http://pages.genemania.org/">GeneMANIA</a> team.</div>
+</div>

--- a/people/nederbragt.lex.html
+++ b/people/nederbragt.lex.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/nederbragt-lex.jpg" alt="Lex Nederbragt" />
+  <div id="nederbragt.lex"
+  class="media-body"><span class="person"><a href="http://flavors.me/flxlex">Lex
+  Nederbragt</a></span> is a self-taught bioinformatician working with
+  high-throughput DNA sequencing data at Oslo University, Norway. His
+  speciality is the assembly of genomes from short pieces of sequence
+  information.</div>
+</div>

--- a/people/pell.j.html
+++ b/people/pell.j.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/pell-jason.jpg" alt="Jason Pell" />
+  <div id="pell.j"
+  class="media-body"><a href="http://www.cse.msu.edu/~pelljaso"><span class="person">Jason
+  Pell</span></a> is a Ph.D. student in Computer Science and Quantitative
+  Biology at Michigan State University who is primarily interested in tackling
+  large next-generation DNA sequencing datasets. He holds a B.A. in Computer
+  Science from Grand Valley State University.</div>
+</div>

--- a/people/perez.f.html
+++ b/people/perez.f.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/perez-fernando.jpg" alt="Fernando Perez" />
+  <div id="perez.f"
+  class="media-body"><a href="http://fperez.org/"><span class="person">Fernando
+  Perez</span></a> is a research scientist at the Helen Wills Neuroscience
+  Institute at U.C. Berkeley. His work involves the development and
+  implementation of new algorithms and tools for neuroimaging, with a special
+  interest in functional MRI. He is also actively involved with the
+  development of new tools for high-level scientific computing, mostly using
+  the Python language.</div>
+</div>

--- a/people/petre.m.html
+++ b/people/petre.m.html
@@ -1,0 +1,12 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/petre-marian.jpg" alt="Marian Petre" />
+  <div id="petre.m"
+  class="media-body"><a href="http://mcs.open.ac.uk/mp8/"><span class="person">Marian
+  Petre</span></a> is a Professor of Computing at the Open University. She
+  holds a Royal Society/Wolfson Research Merit Award in recognition of her
+  research on expertise in software design. With degrees in both
+  Psycholinguistics and Computer Science, Marian's research spans empirical
+  studies of software development, representation and visualisation for
+  software design, psychology of programming, human-centred computing, and
+  computer science education.</div>
+</div>

--- a/people/pickens.c.html
+++ b/people/pickens.c.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/pickens-caitlyn.jpg" alt="Caitlyn Pickens" />
+  <div id="pickens.c"
+  class="media-body"><a href="http://michigancomputes.wordpress.com/"><span class="person">Caitlyn
+  Pickens</span></a> is a graduate student at Michigan State University. She
+  researches education techniques in the undergraduate computer science
+  classroom&mdash;specifically, the flipped classroom and active
+  learning.</div>
+</div>

--- a/people/pipitone.j.html
+++ b/people/pipitone.j.html
@@ -1,0 +1,7 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/pipitone-jon.jpg" alt="Jon Pipitone" />
+  <div id="pipitone.j" class="media-body"><span class="person">Jon
+  Pipitone</span> completed his MSc in Computer Science at the University of
+  Toronto in 2010. He has been active since then in a variety of scientific,
+  environmental, and social justice causes.</div>
+</div>

--- a/people/plumbley.m.html
+++ b/people/plumbley.m.html
@@ -1,0 +1,12 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/plumbley-mark.jpg" alt="Mark Plumbley" />
+  <div id="plumbley.m"
+  class="media-body"><a href="http://www.elec.qmul.ac.uk/people/markp/"><span class="person">Mark
+  Plumbley</span></a> is Director of the Centre for Digital Music (C4DM) at
+  Queen Mary, University of London, and leads
+  the <a href="http://soundsoftware.ac.uk/">SoundSoftware.ac.uk</a>
+  project. His work in audio signal analysis includes beat tracking, music
+  transcription, source separation and object coding, using techniques such as
+  neural networks, independent component analysis, sparse representations and
+  Bayesian modeling.</div>
+</div>

--- a/people/rokem.a.html
+++ b/people/rokem.a.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/rokem-ariel.jpg" alt="Ariel Rokem" />
+  <div id="rokem.a"
+  class="media-body"><span class="person"><a href="http://arokem.org">Ariel
+  Rokem</a></span> is a post-doctoral researcher at the Stanford Psychology
+  Department. His research focuses on the functional neuroanatomy of the human
+  visual system. Since his time as a PhD student at UC Berkeley, he has been
+  involved in developing open source software for neuroimaging.</div>
+</div>

--- a/people/scopatz.a.html
+++ b/people/scopatz.a.html
@@ -1,0 +1,8 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/scopatz-anthony.png" alt="Anthony Scopatz" />
+  <div id="scopatz.a"
+  class="media-body"><a href="http://scopatz.com/"><span class="person">Anthony
+  Scopatz</span></a> has a PhD in Mechanical and Nuclear Engineering from the
+  University of Texas at Austin, and is now a post-doc in the Astrophysics
+  Department's FLASH Center at the University of Chicago.</div>
+</div>

--- a/people/shelton.j.html
+++ b/people/shelton.j.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/shelton-jeff.jpg" alt="Jeff Shelton" />
+  <div id="shelton.j"
+  class="media-body"><a href="http://engineeringrevision.com/about/"><span class="person">Jeff
+  Shelton</span></a> is a PhD candidate in Mechanical Engineering at Purdue
+  University, studying the control aspects of human motion. Following more
+  than two decades in industry, he is interested in aligning educational
+  methods with the evolving societal roles performed by engineers.</div>
+</div>

--- a/people/smith.j.html
+++ b/people/smith.j.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/smith-joshua.jpg" alt="Joshua Ryan Smith" />
+  <div id="smith.j" class="media-body"><span class="person">Joshua Ryan
+  Smith</span> specializes in electronic devices based on wide-bandgap
+  semiconductor materials and in the past has done work in surface science and
+  nanofabrication. Joshua is a native of North Carolina and received his
+  Ph.D. in physics from North Carolina State University; he learned Python
+  programming in graduate school and has an interest in understanding the
+  design of experiments in terms of the practices of software
+  development.</div>
+</div>

--- a/people/supp.s.html
+++ b/people/supp.s.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/supp-sarah.jpg" alt="Sarah Supp" />
+  <div id="supp.s" class="media-body"><span class="person">Sarah Supp</span>
+  is a Ph.D. student in Biology and Ecology at Utah State University. Her
+  research interests lie in combining field studies, macroecological analyses
+  and ecoinformatics to understand the dynamics that drive change at the
+  community and ecosystem level. She uses R, Python, MySQL, and version
+  control to handle the large datasets needed to explore ecological questions
+  focused at large spatiotemporal scales.</div>
+</div>

--- a/people/varoquaux.n.html
+++ b/people/varoquaux.n.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/varoquaux-nelle.jpg" alt="Nelle Varoquaux" />
+  <div id="varoquaux.n" class="media-body">After working as a Python software
+  engineer, <span class="person">Nelle Varoquaux</span> returned to university
+  in 2011 to pursue an applied mathematics degree, specializing in machine
+  learning. She is now interested in using these newly acquired skills to
+  solve biological problems, such as reconstructing the 3D architecture of the
+  genome.</div>
+</div>

--- a/people/viana.a.html
+++ b/people/viana.a.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/viana-alex.jpg" alt="Alex Viana" />
+  <div id="viana.a" class="media-body"><span class="person">Alex Viana</span>
+  is a Research and Instrument Analyst at the <a href="http://stsci.edu">Space
+  Telescope Science Institute</a> where he supports the operations of the
+  Hubble Space Telescope. Primarily working in Python and SQL he has
+  contributed to a wide range of scientific and educational projects at
+  STScI.</div>
+</div>

--- a/people/waugh.b.html
+++ b/people/waugh.b.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/waugh-ben.jpg" alt="Ben Waugh" />
+  <div id="waugh.b"
+  class="media-body"><a href="http://www.hep.ucl.ac.uk/~waugh/"><span class="person">Ben
+  Waugh</span></a> writes and maintains software, teaches programming and a
+  bit of physics, manages computer systems and drinks lots of coffee in
+  the <a href="http://www.phys.ucl.ac.uk/">Department of Physics and
+  Astronomy</a> at <a href="http://www.ucl.ac.uk/">University College
+  London</a>, mostly in the <a href="http://www.hep.ucl.ac.uk/">High-Energy
+  Physics Group</a>.</div>
+</div>

--- a/people/white.e.html
+++ b/people/white.e.html
@@ -1,0 +1,10 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/white-ethan.jpg" alt="Ethan White" />
+  <div id="white.e"
+  class="media-body"><a href="http://ethanwhite.org"><span class="person">Ethan
+  White</span></a> is an Associate Professor in the Department of Biology and
+  the Ecology Center at Utah State University. He is a recipient of the
+  prestigious National Science Foundation CAREER "Young Investigators"
+  Award. He is a proponent of open and reproducible science and serves on the
+  editorial boards of both PLOS ONE and PeerJ.</div>
+</div>

--- a/people/williams.l.html
+++ b/people/williams.l.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/williams-lynne.jpg" alt="Lynne Williams" />
+  <div id="williams.l"
+  class="media-body"><a href="http://research.baycrest.org/lwilliams"><span class="person">Lynne
+  Williams</span></a> works at the Rotman-Baycrest Research Institute, where
+  she studies the cognitive neuroscience of language development over the
+  lifespan and develops statistical techniques to analyze large multivariate
+  data sets.  Her most recent work is concerned with pattern classifiers in
+  brain imaging and age-associated patterns of variability in brain
+  activation.</div>
+</div>

--- a/people/wilson.g.html
+++ b/people/wilson.g.html
@@ -1,0 +1,9 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/wilson-greg.jpg" alt="Greg Wilson" />
+  <div id="wilson.g"
+  class="media-body"><a href="http://www.third-bit.com"><span class="person">Greg
+  Wilson</span></a> started the Software Carpentry project in 1998. He has
+  been a professional software developer, an author, and a university
+  professor. Greg received his PhD in Computer Science from the University of
+  Edinburgh in 1993.</div>
+</div>

--- a/people/wilson.p.html
+++ b/people/wilson.p.html
@@ -1,0 +1,11 @@
+<div class="media">
+  <img class="media-object pull-left" src="{{root_path}}/img/people/wilson-paul.jpg" alt="Paul Wilson" />
+  <div id="wilson.p"
+  class="media-body"><a href="http://cnerg.github.com/"><span class="person">Paul
+  Wilson</span></a> is an Associate Professor at the U. Wisconsin-Madison
+  where he teaches nuclear engineering.  His research
+  group, <a href="http://cnerg.github.com">CNERG</a>, delivers new capability
+  for the simulation of nuclear systems.  The Hacker Within was born from his
+  research group as he tried to impart Software Carpentry skills upon his
+  graduate students. </div>
+</div>


### PR DESCRIPTION
We sometimes need to include blurbs about people in boot camp pages (e.g., the upcoming WiSE camp's page), so separating them into include files.
