### PR TITLE
Fixed location in Washington boot camp page

### DIFF
--- a/bootcamps/2013-07-washington.html
+++ b/bootcamps/2013-07-washington.html
@@ -11,7 +11,7 @@
   <meta name="instructor" content="mandli.kyle" />
 {% endblock file_metadata %}
 {% block content %}
-<p><strong>Where:</strong> Stephenson Research and Technology Center, University of Oklahoma</p>
+<p><strong>Where:</strong> University of Washington</p>
 <p><strong>When:</strong> July 18-19, 2013. We will start at 9:00 and end at 4:30 each day.</p>
 {% include "_instructors.html" %}
 {% include "_what.html" %}


### PR DESCRIPTION
Turns out UWashington camp isn't in Oklahoma! Derp.
